### PR TITLE
Improve Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,20 @@ php:
   - 5.4
   - 5.5
 
-script:
-  - phpunit --coverage-clover build/logs/clover.xml
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_install: composer self-update
+
+install: composer install
 
 before_script:
   - mkdir -p build/logs
-  - composer install
   - mysql -e 'create database `test-db`;'
   - mysql --default-character-set=utf8 test-db < tests/test_data/structure.sql
+
+script: phpunit --coverage-clover build/logs/clover.xml
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
- Use `install` and `before_install` build phases appropriately.
  - Perform `composer self-update` before install.
  - Perform `composer install` on install.
- Cache Composer cache between builds.
