### PR TITLE
Use camelCase for method names

### DIFF
--- a/src/Openbuildings/Cherry/Compiler.php
+++ b/src/Openbuildings/Cherry/Compiler.php
@@ -7,7 +7,7 @@
  */
 class Compiler
 {
-	public static function to_placeholders(array $array)
+	public static function toPlaceholders(array $array)
 	{
 		$placeholders = $array ? join(', ', array_fill(0, count($array), '?')) : '';
 

--- a/src/Openbuildings/Cherry/Compiler/Condition.php
+++ b/src/Openbuildings/Cherry/Compiler/Condition.php
@@ -24,7 +24,7 @@ class Compiler_Condition extends Compiler
 
 			foreach ($condition->parameters() as $index => $value)
 			{
-				$rendered_parameters[$index] = is_array($value) ? Compiler::to_placeholders($value) : '?';
+				$rendered_parameters[$index] = is_array($value) ? Compiler::toPlaceholders($value) : '?';
 			}
 
 			$content = Str::replace('/\?/', $rendered_parameters, $content);

--- a/src/Openbuildings/Cherry/DB.php
+++ b/src/Openbuildings/Cherry/DB.php
@@ -30,7 +30,7 @@ class DB extends \PDO
 		static::$configurations[$name] = $parameters;
 	}
 
-	public static function default_name($default_name = NULL)
+	public static function defaultName($default_name = NULL)
 	{
 		if ($default_name !== NULL)
 		{
@@ -41,7 +41,7 @@ class DB extends \PDO
 
 	public static function instance($name = NULL)
 	{
-		$name = $name ?: static::default_name();
+		$name = $name ?: static::defaultName();
 
 		if ( ! isset(static::$instances[$name]))
 		{

--- a/tests/tests/Compiler/DeleteTest.php
+++ b/tests/tests/Compiler/DeleteTest.php
@@ -14,7 +14,7 @@ class Compiler_DeleteTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\Compiler_Delete::render
 	 */
-	public function test_render()
+	public function testRender()
 	{
 		$delete = new Query_Delete;
 		$delete

--- a/tests/tests/Compiler/InsertTest.php
+++ b/tests/tests/Compiler/InsertTest.php
@@ -12,7 +12,7 @@ use Openbuildings\Cherry\SQL;
 class Integration_Compiler_InsertTest extends Testcase_Extended {
 
 
-	public function data_insert()
+	public function dataInsert()
 	{
 		$rows = array();
 		$args = array();
@@ -69,9 +69,9 @@ SQL;
 
 	/**
 	 * @covers Openbuildings\Cherry\Compiler_Insert::render
-	 * @dataProvider data_insert
+	 * @dataProvider dataInsert
 	 */
-	public function test_insert($query, $expected_sql)
+	public function testInsert($query, $expected_sql)
 	{
 		$this->assertEquals($expected_sql, Compiler_Insert::render($query));
 	}

--- a/tests/tests/Compiler/SelectTest.php
+++ b/tests/tests/Compiler/SelectTest.php
@@ -13,7 +13,7 @@ class Compiler_SelectTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\Compiler_Select::render
 	 */
-	public function test_compile()
+	public function testCompile()
 	{
 		$select2 = new Query_Select;
 		$select2

--- a/tests/tests/Compiler/UpdateTest.php
+++ b/tests/tests/Compiler/UpdateTest.php
@@ -13,7 +13,7 @@ class Compiler_UpdateTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\Compiler_Update::render
 	 */
-	public function test_update()
+	public function testUpdate()
 	{
 
 		$update = new Query_Update;

--- a/tests/tests/CompilerTest.php
+++ b/tests/tests/CompilerTest.php
@@ -7,7 +7,7 @@ use Openbuildings\Cherry\Compiler;
  */
 class CompilerTest extends Testcase_Extended {
 
-	public function data_to_placeholders()
+	public function dataToPlaceholders()
 	{
 		return array(
 			array(array('name1', 'name2'), '(?, ?)'),
@@ -17,15 +17,15 @@ class CompilerTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_to_placeholders
-	 * @covers Openbuildings\Cherry\Compiler::to_placeholders
+	 * @dataProvider dataToPlaceholders
+	 * @covers Openbuildings\Cherry\Compiler::toPlaceholders
 	 */
-	public function test_to_placeholders($array, $expected)
+	public function testToPlaceholders($array, $expected)
 	{
-		$this->assertEquals($expected, Compiler::to_placeholders($array));
+		$this->assertEquals($expected, Compiler::toPlaceholders($array));
 	}
 
-	public function data_expression()
+	public function dataExpression()
 	{
 		return array(
 			array(array('SELECT', '*', NULL, 'WHERE i = 1'), 'SELECT * WHERE i = 1'),
@@ -35,15 +35,15 @@ class CompilerTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_expression
+	 * @dataProvider dataExpression
 	 * @covers Openbuildings\Cherry\Compiler::expression
 	 */
-	public function test_expression($array, $expected)
+	public function testExpression($array, $expected)
 	{
 		$this->assertEquals($expected, Compiler::expression($array));
 	}
 
-	public function data_word()
+	public function dataWord()
 	{
 		return array(
 			array('SELECT', NULL, NULL),
@@ -52,15 +52,15 @@ class CompilerTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_word
+	 * @dataProvider dataWord
 	 * @covers Openbuildings\Cherry\Compiler::word
 	 */
-	public function test_word($word, $statement, $expected)
+	public function testWord($word, $statement, $expected)
 	{
 		$this->assertEquals($expected, Compiler::word($word, $statement));
 	}
 
-	public function data_braced()
+	public function dataBraced()
 	{
 		return array(
 			array('SELECT test', '(SELECT test)'),
@@ -69,15 +69,15 @@ class CompilerTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_braced
+	 * @dataProvider dataBraced
 	 * @covers Openbuildings\Cherry\Compiler::braced
 	 */
-	public function test_braced($statement, $expected)
+	public function testBraced($statement, $expected)
 	{
 		$this->assertEquals($expected, Compiler::braced($statement));
 	}
 
-	public function data_humanize()
+	public function dataHumanize()
 	{
 		return array(
 			array('SELECT test', array(), 'SELECT test'),
@@ -88,10 +88,10 @@ class CompilerTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_humanize
+	 * @dataProvider dataHumanize
 	 * @covers Openbuildings\Cherry\Compiler::humanize
 	 */
-	public function test_humanize($statement, $parameters, $expected)
+	public function testHumanize($statement, $parameters, $expected)
 	{
 		$this->assertEquals($expected, Compiler::humanize($statement, $parameters));
 	}

--- a/tests/tests/DBTest.php
+++ b/tests/tests/DBTest.php
@@ -10,7 +10,7 @@ class DBTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\DB::configuration
 	 */
-	public function test_configuration()
+	public function testConfiguration()
 	{
 		$this->env->backup_and_set(array(
 			'Openbuildings\Cherry\DB::$configurations' => array(),
@@ -24,26 +24,26 @@ class DBTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @covers Openbuildings\Cherry\DB::default_name
+	 * @covers Openbuildings\Cherry\DB::defaultName
 	 */
-	public function test_default_name()
+	public function testDefaultName()
 	{
-		$this->assertEquals('default', DB::default_name());
+		$this->assertEquals('default', DB::defaultName());
 
 		$this->env->backup_and_set(array(
 			'Openbuildings\Cherry\DB::$default_name' => 'test',
 		));
 
-		$this->assertEquals('test', DB::default_name());
-		DB::default_name('default_test');
-		$this->assertEquals('default_test', DB::default_name());
+		$this->assertEquals('test', DB::defaultName());
+		DB::defaultName('default_test');
+		$this->assertEquals('default_test', DB::defaultName());
 	}
 
 	/**
 	 * @covers Openbuildings\Cherry\DB::instance
 	 * @covers Openbuildings\Cherry\DB::__construct
 	 */
-	public function test_instance()
+	public function testInstance()
 	{
 		DB::configuration('default', array(
 			'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
@@ -82,7 +82,7 @@ class DBTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\DB::select
 	 */
-	public function test_select()
+	public function testSelect()
 	{
 		$select = DB::instance()->select()->columns(array('test', 'test2'));
 
@@ -96,7 +96,7 @@ class DBTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\DB::update
 	 */
-	public function test_update()
+	public function testUpdate()
 	{
 		$update = DB::instance()->update()->table(array('test', 'test2'));
 
@@ -110,7 +110,7 @@ class DBTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\DB::delete
 	 */
-	public function test_delete()
+	public function testDelete()
 	{
 		$delete = DB::instance()->delete()->from(array('test', 'test2'));
 
@@ -124,7 +124,7 @@ class DBTest extends Testcase_Extended {
 	/**
 	 * @covers Openbuildings\Cherry\DB::insert
 	 */
-	public function test_insert()
+	public function testInsert()
 	{
 		$query = DB::instance()->insert()->into('table1')->set(array('name' => 'test2'));
 

--- a/tests/tests/StrTest.php
+++ b/tests/tests/StrTest.php
@@ -7,7 +7,7 @@ use Openbuildings\Cherry\Str;
  */
 class StrTest extends Testcase_Extended {
 
-	public function data_replace()
+	public function dataReplace()
 	{
 		return array(
 			array("/\?/", array('1', '2'), "this is ? a test ? here", "this is 1 a test 2 here"),
@@ -17,10 +17,10 @@ class StrTest extends Testcase_Extended {
 	}
 
 	/**
-	 * @dataProvider data_replace
+	 * @dataProvider dataReplace
 	 * @covers Openbuildings\Cherry\Str::replace
 	 */
-	public function test_replace($pattern, $replacements, $subject, $expected)
+	public function testReplace($pattern, $replacements, $subject, $expected)
 	{
 		$this->assertEquals($expected, Str::replace($pattern, $replacements, $subject));
 	}


### PR DESCRIPTION
Method names should be written with camelCase.

Here are some examples from the project:
- Arr::toAssoc
- Arr::toArray
- Arr::toObjects
- Query::addChildren
- Query::addChildrenObjects
