### PR TITLE
Convert codebase to PSR-2 coding standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending for every file
+# Indent with 4 spaces
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# Indent XML with tabs
+[xml]
+indent_style = tab

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -2,6 +2,8 @@ filter:
   paths: [src/*]
 
 tools:
+  php_cs_fixer:
+    config: { level: psr2 }
   external_code_coverage: true
   php_cpd: true
   php_hhvm: true

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -69,7 +69,7 @@ class Arr
     {
         $result = array();
 
-        array_walk_recursive($array, function($value, $key) use ( & $result) {
+        array_walk_recursive($array, function ($value, $key) use ( & $result) {
             if (is_numeric($key) or is_object($value)) {
                 $result[] = $value;
             } else {

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -69,7 +69,7 @@ class Arr
     {
         $result = array();
 
-        array_walk_recursive($array, function ($value, $key) use ( & $result) {
+        array_walk_recursive($array, function ($value, $key) use (& $result) {
             if (is_numeric($key) or is_object($value)) {
                 $result[] = $value;
             } else {

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -34,6 +34,7 @@ class Arr
         if ( ! is_array($array)) {
             return array($array);
         }
+
         return $array;
     }
 

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -31,7 +31,7 @@ class Arr
      */
     public static function toArray($array)
     {
-        if ( ! is_array($array)) {
+        if (! is_array($array)) {
             return array($array);
         }
 

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -15,14 +15,10 @@ class Arr
     {
         $converted = array();
 
-        foreach ($array as $key => $value)
-        {
-            if (is_numeric($key) AND ! is_object($value))
-            {
+        foreach ($array as $key => $value) {
+            if (is_numeric($key) AND ! is_object($value)) {
                 $converted[$value] = NULL;
-            }
-            else
-            {
+            } else {
                 $converted[$key] = $value;
             }
         }
@@ -35,8 +31,7 @@ class Arr
      */
     public static function toArray($array)
     {
-        if ( ! is_array($array))
-        {
+        if ( ! is_array($array)) {
             return array($array);
         }
         return $array;
@@ -46,16 +41,12 @@ class Arr
     {
         $objects = array();
 
-        if ($argument !== NULL)
-        {
+        if ($argument !== NULL) {
             $objects []= call_user_func($callback, $array, $argument);
-        }
-        else
-        {
+        } else {
             $array = Arr::toAssoc(Arr::toArray($array));
 
-            foreach ($array as $param => $argument)
-            {
+            foreach ($array as $param => $argument) {
                 $objects []= is_object($argument) ? $argument : call_user_func($callback, $param, $argument);
             }
         }
@@ -78,12 +69,9 @@ class Arr
         $result = array();
 
         array_walk_recursive($array, function($value, $key) use ( & $result) {
-            if (is_numeric($key) OR is_object($value))
-            {
+            if (is_numeric($key) OR is_object($value)) {
                 $result[] = $value;
-            }
-            else
-            {
+            } else {
                 $result[$key] = $value;
             }
         });

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -16,8 +16,8 @@ class Arr
         $converted = array();
 
         foreach ($array as $key => $value) {
-            if (is_numeric($key) AND ! is_object($value)) {
-                $converted[$value] = NULL;
+            if (is_numeric($key) and ! is_object($value)) {
+                $converted[$value] = null;
             } else {
                 $converted[$key] = $value;
             }
@@ -41,7 +41,7 @@ class Arr
     {
         $objects = array();
 
-        if ($argument !== NULL) {
+        if ($argument !== null) {
             $objects []= call_user_func($callback, $array, $argument);
         } else {
             $array = Arr::toAssoc(Arr::toArray($array));
@@ -56,12 +56,12 @@ class Arr
 
     public static function map($callback, $array)
     {
-        return $array ? array_map($callback, $array) : NULL;
+        return $array ? array_map($callback, $array) : null;
     }
 
     public static function join($separator, $array)
     {
-        return $array ? join($separator, $array) : NULL;
+        return $array ? join($separator, $array) : null;
     }
 
     public static function flatten(array $array)
@@ -69,7 +69,7 @@ class Arr
         $result = array();
 
         array_walk_recursive($array, function($value, $key) use ( & $result) {
-            if (is_numeric($key) OR is_object($value)) {
+            if (is_numeric($key) or is_object($value)) {
                 $result[] = $value;
             } else {
                 $result[$key] = $value;

--- a/src/Arr.php
+++ b/src/Arr.php
@@ -11,83 +11,83 @@ namespace CL\Atlas;
  */
 class Arr
 {
-	public static function toAssoc(array $array)
-	{
-		$converted = array();
+    public static function toAssoc(array $array)
+    {
+        $converted = array();
 
-		foreach ($array as $key => $value)
-		{
-			if (is_numeric($key) AND ! is_object($value))
-			{
-				$converted[$value] = NULL;
-			}
-			else
-			{
-				$converted[$key] = $value;
-			}
-		}
+        foreach ($array as $key => $value)
+        {
+            if (is_numeric($key) AND ! is_object($value))
+            {
+                $converted[$value] = NULL;
+            }
+            else
+            {
+                $converted[$key] = $value;
+            }
+        }
 
-		return $converted;
-	}
+        return $converted;
+    }
 
-	/**
-	 * convert to an array - if not an array, make one with a single item - the source object
-	 */
-	public static function toArray($array)
-	{
-		if ( ! is_array($array))
-		{
-			return array($array);
-		}
-		return $array;
-	}
+    /**
+     * convert to an array - if not an array, make one with a single item - the source object
+     */
+    public static function toArray($array)
+    {
+        if ( ! is_array($array))
+        {
+            return array($array);
+        }
+        return $array;
+    }
 
-	public static function toObjects($array, $argument, $callback)
-	{
-		$objects = array();
+    public static function toObjects($array, $argument, $callback)
+    {
+        $objects = array();
 
-		if ($argument !== NULL)
-		{
-			$objects []= call_user_func($callback, $array, $argument);
-		}
-		else
-		{
-			$array = Arr::toAssoc(Arr::toArray($array));
+        if ($argument !== NULL)
+        {
+            $objects []= call_user_func($callback, $array, $argument);
+        }
+        else
+        {
+            $array = Arr::toAssoc(Arr::toArray($array));
 
-			foreach ($array as $param => $argument)
-			{
-				$objects []= is_object($argument) ? $argument : call_user_func($callback, $param, $argument);
-			}
-		}
+            foreach ($array as $param => $argument)
+            {
+                $objects []= is_object($argument) ? $argument : call_user_func($callback, $param, $argument);
+            }
+        }
 
-		return $objects;
-	}
+        return $objects;
+    }
 
-	public static function map($callback, $array)
-	{
-		return $array ? array_map($callback, $array) : NULL;
-	}
+    public static function map($callback, $array)
+    {
+        return $array ? array_map($callback, $array) : NULL;
+    }
 
-	public static function join($separator, $array)
-	{
-		return $array ? join($separator, $array) : NULL;
-	}
+    public static function join($separator, $array)
+    {
+        return $array ? join($separator, $array) : NULL;
+    }
 
-	public static function flatten(array $array)
-	{
-		$result = array();
+    public static function flatten(array $array)
+    {
+        $result = array();
 
-		array_walk_recursive($array, function($value, $key) use ( & $result) {
-			if (is_numeric($key) OR is_object($value))
-			{
-				$result[] = $value;
-			}
-			else
-			{
-				$result[$key] = $value;
-			}
-		});
+        array_walk_recursive($array, function($value, $key) use ( & $result) {
+            if (is_numeric($key) OR is_object($value))
+            {
+                $result[] = $value;
+            }
+            else
+            {
+                $result[$key] = $value;
+            }
+        });
 
-		return $result;
-	}
+        return $result;
+    }
 }

--- a/src/Compiler/AliasedCompiler.php
+++ b/src/Compiler/AliasedCompiler.php
@@ -22,8 +22,7 @@ class AliasedCompiler extends Compiler
     {
         $content = $aliased->content();
 
-        if ($content instanceof SelectQuery)
-        {
+        if ($content instanceof SelectQuery) {
             $content = "(".SelectCompiler::render($content).")";
         }
 

--- a/src/Compiler/AliasedCompiler.php
+++ b/src/Compiler/AliasedCompiler.php
@@ -13,23 +13,23 @@ use CL\Atlas\Compiler\SelectCompiler;
  */
 class AliasedCompiler extends Compiler
 {
-	public static function combine($items)
-	{
-		return Arr::join(', ', Arr::map('CL\Atlas\Compiler\AliasedCompiler::render', $items));
-	}
+    public static function combine($items)
+    {
+        return Arr::join(', ', Arr::map('CL\Atlas\Compiler\AliasedCompiler::render', $items));
+    }
 
-	public static function render(AliasedSQL $aliased)
-	{
-		$content = $aliased->content();
+    public static function render(AliasedSQL $aliased)
+    {
+        $content = $aliased->content();
 
-		if ($content instanceof SelectQuery)
-		{
-			$content = "(".SelectCompiler::render($content).")";
-		}
+        if ($content instanceof SelectQuery)
+        {
+            $content = "(".SelectCompiler::render($content).")";
+        }
 
-		return Compiler::expression(array(
-			$content,
-			Compiler::word('AS', $aliased->alias())
-		));
-	}
+        return Compiler::expression(array(
+            $content,
+            Compiler::word('AS', $aliased->alias())
+        ));
+    }
 }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -36,7 +36,7 @@ class Compiler
         foreach ($parameters as & $param) {
             if (is_null($param)) {
                 $param = 'NULL';
-            } elseif ( ! (is_int($param) or is_bool($param))) {
+            } elseif (! (is_int($param) or is_bool($param))) {
                 $param = "\"{$param}\"";
             }
         }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -23,12 +23,12 @@ class Compiler
 
     public static function word($statement, $content)
     {
-        return $content ? $statement.' '.$content : NULL;
+        return $content ? $statement.' '.$content : null;
     }
 
     public static function braced($content)
     {
-        return $content ? "($content)" : NULL;
+        return $content ? "($content)" : null;
     }
 
     public static function humanize($sql, $parameters)
@@ -36,7 +36,7 @@ class Compiler
         foreach ($parameters as & $param) {
             if (is_null($param)) {
                 $param = 'NULL';
-            } elseif ( ! (is_int($param) OR is_bool($param))) {
+            } elseif ( ! (is_int($param) or is_bool($param))) {
                 $param = "\"{$param}\"";
             }
         }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -9,41 +9,41 @@ use CL\Atlas\Str;
  */
 class Compiler
 {
-	public static function toPlaceholders(array $array)
-	{
-		$placeholders = $array ? join(', ', array_fill(0, count($array), '?')) : '';
+    public static function toPlaceholders(array $array)
+    {
+        $placeholders = $array ? join(', ', array_fill(0, count($array), '?')) : '';
 
-		return "($placeholders)";
-	}
+        return "($placeholders)";
+    }
 
-	public static function expression(array $parts)
-	{
-		return implode(' ', array_filter($parts));
-	}
+    public static function expression(array $parts)
+    {
+        return implode(' ', array_filter($parts));
+    }
 
-	public static function word($statement, $content)
-	{
-		return $content ? $statement.' '.$content : NULL;
-	}
+    public static function word($statement, $content)
+    {
+        return $content ? $statement.' '.$content : NULL;
+    }
 
-	public static function braced($content)
-	{
-		return $content ? "($content)" : NULL;
-	}
+    public static function braced($content)
+    {
+        return $content ? "($content)" : NULL;
+    }
 
-	public static function humanize($sql, $parameters)
-	{
-		foreach ($parameters as & $param)
-		{
-			if (is_null($param))
-			{
-				$param = 'NULL';
-			}
-			elseif ( ! (is_int($param) OR is_bool($param)))
-			{
-				$param = "\"{$param}\"";
-			}
-		}
-		return Str::replace('/\?/', $parameters, $sql);
-	}
+    public static function humanize($sql, $parameters)
+    {
+        foreach ($parameters as & $param)
+        {
+            if (is_null($param))
+            {
+                $param = 'NULL';
+            }
+            elseif ( ! (is_int($param) OR is_bool($param)))
+            {
+                $param = "\"{$param}\"";
+            }
+        }
+        return Str::replace('/\?/', $parameters, $sql);
+    }
 }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -33,14 +33,10 @@ class Compiler
 
     public static function humanize($sql, $parameters)
     {
-        foreach ($parameters as & $param)
-        {
-            if (is_null($param))
-            {
+        foreach ($parameters as & $param) {
+            if (is_null($param)) {
                 $param = 'NULL';
-            }
-            elseif ( ! (is_int($param) OR is_bool($param)))
-            {
+            } elseif ( ! (is_int($param) OR is_bool($param))) {
                 $param = "\"{$param}\"";
             }
         }

--- a/src/Compiler/Compiler.php
+++ b/src/Compiler/Compiler.php
@@ -40,6 +40,7 @@ class Compiler
                 $param = "\"{$param}\"";
             }
         }
+
         return Str::replace('/\?/', $parameters, $sql);
     }
 }

--- a/src/Compiler/ConditionCompiler.php
+++ b/src/Compiler/ConditionCompiler.php
@@ -22,12 +22,10 @@ class ConditionCompiler extends Compiler
     {
         $content = $condition->content();
 
-        if ($condition->parameters() AND array_filter($condition->parameters(), 'is_array')) 
-        {
+        if ($condition->parameters() AND array_filter($condition->parameters(), 'is_array')) {
             $rendered_parameters = array();
 
-            foreach ($condition->parameters() as $index => $value)
-            {
+            foreach ($condition->parameters() as $index => $value) {
                 $rendered_parameters[$index] = is_array($value) ? Compiler::toPlaceholders($value) : '?';
             }
 

--- a/src/Compiler/ConditionCompiler.php
+++ b/src/Compiler/ConditionCompiler.php
@@ -22,7 +22,7 @@ class ConditionCompiler extends Compiler
     {
         $content = $condition->content();
 
-        if ($condition->parameters() AND array_filter($condition->parameters(), 'is_array')) {
+        if ($condition->parameters() and array_filter($condition->parameters(), 'is_array')) {
             $rendered_parameters = array();
 
             foreach ($condition->parameters() as $index => $value) {

--- a/src/Compiler/ConditionCompiler.php
+++ b/src/Compiler/ConditionCompiler.php
@@ -11,29 +11,29 @@ use CL\Atlas\SQL\ConditionSQL;
  */
 class ConditionCompiler extends Compiler
 {
-	public static function combine($conditions)
-	{
-		return Arr::join(' AND ', Arr::map(function($condition) {
-			return "(".ConditionCompiler::render($condition).")";
-		}, $conditions));
-	}
+    public static function combine($conditions)
+    {
+        return Arr::join(' AND ', Arr::map(function($condition) {
+            return "(".ConditionCompiler::render($condition).")";
+        }, $conditions));
+    }
 
-	public static function render(ConditionSQL $condition)
-	{
-		$content = $condition->content();
+    public static function render(ConditionSQL $condition)
+    {
+        $content = $condition->content();
 
-		if ($condition->parameters() AND array_filter($condition->parameters(), 'is_array')) 
-		{
-			$rendered_parameters = array();
+        if ($condition->parameters() AND array_filter($condition->parameters(), 'is_array')) 
+        {
+            $rendered_parameters = array();
 
-			foreach ($condition->parameters() as $index => $value)
-			{
-				$rendered_parameters[$index] = is_array($value) ? Compiler::toPlaceholders($value) : '?';
-			}
+            foreach ($condition->parameters() as $index => $value)
+            {
+                $rendered_parameters[$index] = is_array($value) ? Compiler::toPlaceholders($value) : '?';
+            }
 
-			$content = Str::replace('/\?/', $rendered_parameters, $content);
-		}
+            $content = Str::replace('/\?/', $rendered_parameters, $content);
+        }
 
-		return $content;
-	}
+        return $content;
+    }
 }

--- a/src/Compiler/ConditionCompiler.php
+++ b/src/Compiler/ConditionCompiler.php
@@ -13,7 +13,7 @@ class ConditionCompiler extends Compiler
 {
     public static function combine($conditions)
     {
-        return Arr::join(' AND ', Arr::map(function($condition) {
+        return Arr::join(' AND ', Arr::map(function ($condition) {
             return "(".ConditionCompiler::render($condition).")";
         }, $conditions));
     }

--- a/src/Compiler/DeleteCompiler.php
+++ b/src/Compiler/DeleteCompiler.php
@@ -17,23 +17,27 @@ class DeleteCompiler extends Compiler
             'DELETE',
             $query->children(Query::TYPE),
             Arr::join(', ', $query->children(Query::TABLE)),
-            Compiler::word('FROM',
+            Compiler::word(
+                'FROM',
                 AliasedCompiler::combine($query->children(Query::FROM))
             ),
             JoinCompiler::combine(
                 $query->children(Query::JOIN)
             ),
-            Compiler::word('WHERE',
+            Compiler::word(
+                'WHERE',
                 ConditionCompiler::combine(
                     $query->children(Query::WHERE)
                 )
             ),
-            Compiler::word('ORDER BY',
+            Compiler::word(
+                'ORDER BY',
                 DirectionCompiler::combine(
                     $query->children(Query::ORDER_BY)
                 )
             ),
-            Compiler::word('LIMIT',
+            Compiler::word(
+                'LIMIT',
                 $query->children(Query::LIMIT)
             ),
         ));

--- a/src/Compiler/DeleteCompiler.php
+++ b/src/Compiler/DeleteCompiler.php
@@ -11,31 +11,31 @@ use CL\Atlas\Query\DeleteQuery;
  */
 class DeleteCompiler extends Compiler
 {
-	public static function render(DeleteQuery $query)
-	{
-		return Compiler::expression(array(
-			'DELETE',
-			$query->children(Query::TYPE),
-			Arr::join(', ', $query->children(Query::TABLE)),
-			Compiler::word('FROM',
-				AliasedCompiler::combine($query->children(Query::FROM))
-			),
-			JoinCompiler::combine(
-				$query->children(Query::JOIN)
-			),
-			Compiler::word('WHERE',
-				ConditionCompiler::combine(
-					$query->children(Query::WHERE)
-				)
-			),
-			Compiler::word('ORDER BY',
-				DirectionCompiler::combine(
-					$query->children(Query::ORDER_BY)
-				)
-			),
-			Compiler::word('LIMIT',
-				$query->children(Query::LIMIT)
-			),
-		));
-	}
+    public static function render(DeleteQuery $query)
+    {
+        return Compiler::expression(array(
+            'DELETE',
+            $query->children(Query::TYPE),
+            Arr::join(', ', $query->children(Query::TABLE)),
+            Compiler::word('FROM',
+                AliasedCompiler::combine($query->children(Query::FROM))
+            ),
+            JoinCompiler::combine(
+                $query->children(Query::JOIN)
+            ),
+            Compiler::word('WHERE',
+                ConditionCompiler::combine(
+                    $query->children(Query::WHERE)
+                )
+            ),
+            Compiler::word('ORDER BY',
+                DirectionCompiler::combine(
+                    $query->children(Query::ORDER_BY)
+                )
+            ),
+            Compiler::word('LIMIT',
+                $query->children(Query::LIMIT)
+            ),
+        ));
+    }
 }

--- a/src/Compiler/DirectionCompiler.php
+++ b/src/Compiler/DirectionCompiler.php
@@ -10,16 +10,16 @@ use CL\Atlas\SQL\DirectionSQL;
  */
 class DirectionCompiler extends Compiler
 {
-	public static function combine($items)
-	{
-		return Arr::join(', ', Arr::map(__NAMESPACE__."\DirectionCompiler::render", $items));
-	}
+    public static function combine($items)
+    {
+        return Arr::join(', ', Arr::map(__NAMESPACE__."\DirectionCompiler::render", $items));
+    }
 
-	public static function render(DirectionSQL $item)
-	{
-		return Compiler::expression(array(
-			$item->content(),
-			$item->direction(),
-		));
-	}
+    public static function render(DirectionSQL $item)
+    {
+        return Compiler::expression(array(
+            $item->content(),
+            $item->direction(),
+        ));
+    }
 }

--- a/src/Compiler/InsertCompiler.php
+++ b/src/Compiler/InsertCompiler.php
@@ -36,7 +36,9 @@ class InsertCompiler extends Compiler
                     $query->children(Query::WHERE)
                 )
             ),
-            $query->children(Query::SELECT) ? SelectCompiler::render($query->children(Query::SELECT)) : null,
+            $query->children(Query::SELECT)
+                ? SelectCompiler::render($query->children(Query::SELECT))
+                : null,
         ));
     }
 }

--- a/src/Compiler/InsertCompiler.php
+++ b/src/Compiler/InsertCompiler.php
@@ -35,7 +35,7 @@ class InsertCompiler extends Compiler
                     $query->children(Query::WHERE)
                 )
             ),
-            $query->children(Query::SELECT) ? SelectCompiler::render($query->children(Query::SELECT)) : NULL,
+            $query->children(Query::SELECT) ? SelectCompiler::render($query->children(Query::SELECT)) : null,
         ));
     }
 }

--- a/src/Compiler/InsertCompiler.php
+++ b/src/Compiler/InsertCompiler.php
@@ -18,19 +18,20 @@ class InsertCompiler extends Compiler
             $query->children(Query::TYPE),
             Compiler::word('INTO', $query->children(Query::TABLE)),
             Compiler::braced(
-                Arr::join(', ',
-                    $query->children(Query::COLUMNS)
-                )
+                Arr::join(', ', $query->children(Query::COLUMNS))
             ),
-            Compiler::word('VALUES',
+            Compiler::word(
+                'VALUES',
                 ValuesCompiler::combine($query->children(Query::VALUES))
             ),
-            Compiler::word('SET',
+            Compiler::word(
+                'SET',
                 SetCompiler::combine(
                     $query->children(Query::SET)
                 )
             ),
-            Compiler::word('SELECT',
+            Compiler::word(
+                'SELECT',
                 ConditionCompiler::combine(
                     $query->children(Query::WHERE)
                 )

--- a/src/Compiler/InsertCompiler.php
+++ b/src/Compiler/InsertCompiler.php
@@ -11,31 +11,31 @@ use CL\Atlas\Query\InsertQuery;
  */
 class InsertCompiler extends Compiler
 {
-	public static function render(InsertQuery $query)
-	{
-		return Compiler::expression(array(
-			'INSERT',
-			$query->children(Query::TYPE),
-			Compiler::word('INTO', $query->children(Query::TABLE)),
-			Compiler::braced(
-				Arr::join(', ',
-					$query->children(Query::COLUMNS)
-				)
-			),
-			Compiler::word('VALUES',
-				ValuesCompiler::combine($query->children(Query::VALUES))
-			),
-			Compiler::word('SET',
-				SetCompiler::combine(
-					$query->children(Query::SET)
-				)
-			),
-			Compiler::word('SELECT',
-				ConditionCompiler::combine(
-					$query->children(Query::WHERE)
-				)
-			),
-			$query->children(Query::SELECT) ? SelectCompiler::render($query->children(Query::SELECT)) : NULL,
-		));
-	}
+    public static function render(InsertQuery $query)
+    {
+        return Compiler::expression(array(
+            'INSERT',
+            $query->children(Query::TYPE),
+            Compiler::word('INTO', $query->children(Query::TABLE)),
+            Compiler::braced(
+                Arr::join(', ',
+                    $query->children(Query::COLUMNS)
+                )
+            ),
+            Compiler::word('VALUES',
+                ValuesCompiler::combine($query->children(Query::VALUES))
+            ),
+            Compiler::word('SET',
+                SetCompiler::combine(
+                    $query->children(Query::SET)
+                )
+            ),
+            Compiler::word('SELECT',
+                ConditionCompiler::combine(
+                    $query->children(Query::WHERE)
+                )
+            ),
+            $query->children(Query::SELECT) ? SelectCompiler::render($query->children(Query::SELECT)) : NULL,
+        ));
+    }
 }

--- a/src/Compiler/JoinCompiler.php
+++ b/src/Compiler/JoinCompiler.php
@@ -21,7 +21,9 @@ class JoinCompiler extends Compiler
         return self::expression(array(
             $join->type(),
             'JOIN',
-            $join->table() instanceof AliasedSQL ? AliasedCompiler::render($join->table()) : $join->table(),
+            $join->table() instanceof AliasedSQL
+                ? AliasedCompiler::render($join->table())
+                : $join->table(),
             $join->condition(),
         ));
     }

--- a/src/Compiler/JoinCompiler.php
+++ b/src/Compiler/JoinCompiler.php
@@ -11,18 +11,18 @@ use CL\Atlas\SQL\JoinSQL;
  */
 class JoinCompiler extends Compiler
 {
-	public static function combine($items)
-	{
-		return Arr::join(' ', Arr::map(__NAMESPACE__."\JoinCompiler::render", $items));
-	}
+    public static function combine($items)
+    {
+        return Arr::join(' ', Arr::map(__NAMESPACE__."\JoinCompiler::render", $items));
+    }
 
-	public static function render(JoinSQL $join)
-	{
-		return self::expression(array(
-			$join->type(),
-			'JOIN',
-			$join->table() instanceof AliasedSQL ? AliasedCompiler::render($join->table()) : $join->table(),
-			$join->condition(),
-		));
-	}
+    public static function render(JoinSQL $join)
+    {
+        return self::expression(array(
+            $join->type(),
+            'JOIN',
+            $join->table() instanceof AliasedSQL ? AliasedCompiler::render($join->table()) : $join->table(),
+            $join->condition(),
+        ));
+    }
 }

--- a/src/Compiler/SelectCompiler.php
+++ b/src/Compiler/SelectCompiler.php
@@ -16,36 +16,43 @@ class SelectCompiler extends Compiler
             'SELECT',
             $query->children(Query::TYPE),
             AliasedCompiler::combine($query->children(Query::COLUMNS)) ?: '*',
-            Compiler::word('FROM',
+            Compiler::word(
+                'FROM',
                 AliasedCompiler::combine($query->children(Query::FROM))
             ),
             JoinCompiler::combine(
                 $query->children(Query::JOIN)
             ),
-            Compiler::word('WHERE',
+            Compiler::word(
+                'WHERE',
                 ConditionCompiler::combine(
                     $query->children(Query::WHERE)
                 )
             ),
-            Compiler::word('GROUP BY',
+            Compiler::word(
+                'GROUP BY',
                 DirectionCompiler::combine(
                     $query->children(Query::GROUP_BY)
                 )
             ),
-            Compiler::word('HAVING',
+            Compiler::word(
+                'HAVING',
                 ConditionCompiler::combine(
                     $query->children(Query::HAVING)
                 )
             ),
-            Compiler::word('ORDER BY',
+            Compiler::word(
+                'ORDER BY',
                 DirectionCompiler::combine(
                     $query->children(Query::ORDER_BY)
                 )
             ),
-            Compiler::word('LIMIT',
+            Compiler::word(
+                'LIMIT',
                 $query->children(Query::LIMIT)
             ),
-            Compiler::word('OFFSET',
+            Compiler::word(
+                'OFFSET',
                 $query->children(Query::OFFSET)
             ),
         ));

--- a/src/Compiler/SelectCompiler.php
+++ b/src/Compiler/SelectCompiler.php
@@ -10,44 +10,44 @@ use CL\Atlas\Query\SelectQuery;
  */
 class SelectCompiler extends Compiler
 {
-	public static function render(SelectQuery $query)
-	{
-		return Compiler::expression(array(
-			'SELECT',
-			$query->children(Query::TYPE),
-			AliasedCompiler::combine($query->children(Query::COLUMNS)) ?: '*',
-			Compiler::word('FROM',
-				AliasedCompiler::combine($query->children(Query::FROM))
-			),
-			JoinCompiler::combine(
-				$query->children(Query::JOIN)
-			),
-			Compiler::word('WHERE',
-				ConditionCompiler::combine(
-					$query->children(Query::WHERE)
-				)
-			),
-			Compiler::word('GROUP BY',
-				DirectionCompiler::combine(
-					$query->children(Query::GROUP_BY)
-				)
-			),
-			Compiler::word('HAVING',
-				ConditionCompiler::combine(
-					$query->children(Query::HAVING)
-				)
-			),
-			Compiler::word('ORDER BY',
-				DirectionCompiler::combine(
-					$query->children(Query::ORDER_BY)
-				)
-			),
-			Compiler::word('LIMIT',
-				$query->children(Query::LIMIT)
-			),
-			Compiler::word('OFFSET',
-				$query->children(Query::OFFSET)
-			),
-		));
-	}
+    public static function render(SelectQuery $query)
+    {
+        return Compiler::expression(array(
+            'SELECT',
+            $query->children(Query::TYPE),
+            AliasedCompiler::combine($query->children(Query::COLUMNS)) ?: '*',
+            Compiler::word('FROM',
+                AliasedCompiler::combine($query->children(Query::FROM))
+            ),
+            JoinCompiler::combine(
+                $query->children(Query::JOIN)
+            ),
+            Compiler::word('WHERE',
+                ConditionCompiler::combine(
+                    $query->children(Query::WHERE)
+                )
+            ),
+            Compiler::word('GROUP BY',
+                DirectionCompiler::combine(
+                    $query->children(Query::GROUP_BY)
+                )
+            ),
+            Compiler::word('HAVING',
+                ConditionCompiler::combine(
+                    $query->children(Query::HAVING)
+                )
+            ),
+            Compiler::word('ORDER BY',
+                DirectionCompiler::combine(
+                    $query->children(Query::ORDER_BY)
+                )
+            ),
+            Compiler::word('LIMIT',
+                $query->children(Query::LIMIT)
+            ),
+            Compiler::word('OFFSET',
+                $query->children(Query::OFFSET)
+            ),
+        ));
+    }
 }

--- a/src/Compiler/SetCompiler.php
+++ b/src/Compiler/SetCompiler.php
@@ -19,16 +19,11 @@ class SetCompiler extends Compiler
 
     public static function render(SetSQL $item)
     {
-        if ($item->value() instanceof SQL)
-        {
+        if ($item->value() instanceof SQL) {
             $value = $item->value()->content();
-        }
-        elseif ($item->value() instanceof SelectQuery)
-        {
+        } elseif ($item->value() instanceof SelectQuery) {
             $value = Compiler::braced(SelectCompiler::render($item->value()));
-        }
-        else
-        {
+        } else {
             $value = '?';
         }
 

--- a/src/Compiler/SetCompiler.php
+++ b/src/Compiler/SetCompiler.php
@@ -12,26 +12,26 @@ use CL\Atlas\Query\SelectQuery;
  */
 class SetCompiler extends Compiler
 {
-	public static function combine($items)
-	{
-		return Arr::join(', ', Arr::map(__NAMESPACE__."\SetCompiler::render", $items));
-	}
+    public static function combine($items)
+    {
+        return Arr::join(', ', Arr::map(__NAMESPACE__."\SetCompiler::render", $items));
+    }
 
-	public static function render(SetSQL $item)
-	{
-		if ($item->value() instanceof SQL)
-		{
-			$value = $item->value()->content();
-		}
-		elseif ($item->value() instanceof SelectQuery)
-		{
-			$value = Compiler::braced(SelectCompiler::render($item->value()));
-		}
-		else
-		{
-			$value = '?';
-		}
+    public static function render(SetSQL $item)
+    {
+        if ($item->value() instanceof SQL)
+        {
+            $value = $item->value()->content();
+        }
+        elseif ($item->value() instanceof SelectQuery)
+        {
+            $value = Compiler::braced(SelectCompiler::render($item->value()));
+        }
+        else
+        {
+            $value = '?';
+        }
 
-		return $item->content().' = '.$value;
-	}
+        return $item->content().' = '.$value;
+    }
 }

--- a/src/Compiler/UpdateCompiler.php
+++ b/src/Compiler/UpdateCompiler.php
@@ -10,33 +10,33 @@ use CL\Atlas\Query\UpdateQuery;
  */
 class UpdateCompiler extends Compiler
 {
-	public static function render(UpdateQuery $query)
-	{
-		return Compiler::expression(array(
-			'UPDATE',
-			$query->children(Query::TYPE),
-			AliasedCompiler::combine($query->children(Query::TABLE)),
-			JoinCompiler::combine(
-				$query->children(Query::JOIN)
-			),
-			Compiler::word('SET',
-				SetCompiler::combine(
-					$query->children(Query::SET)
-				)
-			),
-			Compiler::word('WHERE',
-				ConditionCompiler::combine(
-					$query->children(Query::WHERE)
-				)
-			),
-			Compiler::word('ORDER BY',
-				DirectionCompiler::combine(
-					$query->children(Query::ORDER_BY)
-				)
-			),
-			Compiler::word('LIMIT',
-				$query->children(Query::LIMIT)
-			),
-		));
-	}
+    public static function render(UpdateQuery $query)
+    {
+        return Compiler::expression(array(
+            'UPDATE',
+            $query->children(Query::TYPE),
+            AliasedCompiler::combine($query->children(Query::TABLE)),
+            JoinCompiler::combine(
+                $query->children(Query::JOIN)
+            ),
+            Compiler::word('SET',
+                SetCompiler::combine(
+                    $query->children(Query::SET)
+                )
+            ),
+            Compiler::word('WHERE',
+                ConditionCompiler::combine(
+                    $query->children(Query::WHERE)
+                )
+            ),
+            Compiler::word('ORDER BY',
+                DirectionCompiler::combine(
+                    $query->children(Query::ORDER_BY)
+                )
+            ),
+            Compiler::word('LIMIT',
+                $query->children(Query::LIMIT)
+            ),
+        ));
+    }
 }

--- a/src/Compiler/UpdateCompiler.php
+++ b/src/Compiler/UpdateCompiler.php
@@ -19,22 +19,26 @@ class UpdateCompiler extends Compiler
             JoinCompiler::combine(
                 $query->children(Query::JOIN)
             ),
-            Compiler::word('SET',
+            Compiler::word(
+                'SET',
                 SetCompiler::combine(
                     $query->children(Query::SET)
                 )
             ),
-            Compiler::word('WHERE',
+            Compiler::word(
+                'WHERE',
                 ConditionCompiler::combine(
                     $query->children(Query::WHERE)
                 )
             ),
-            Compiler::word('ORDER BY',
+            Compiler::word(
+                'ORDER BY',
                 DirectionCompiler::combine(
                     $query->children(Query::ORDER_BY)
                 )
             ),
-            Compiler::word('LIMIT',
+            Compiler::word(
+                'LIMIT',
                 $query->children(Query::LIMIT)
             ),
         ));

--- a/src/Compiler/ValuesCompiler.php
+++ b/src/Compiler/ValuesCompiler.php
@@ -10,15 +10,15 @@ use CL\Atlas\SQL\ValuesSQL;
  */
 class ValuesCompiler extends Compiler
 {
-	public static function combine($items)
-	{
-		return Arr::join(', ', Arr::map(__NAMESPACE__."\ValuesCompiler::render", $items));
-	}
+    public static function combine($items)
+    {
+        return Arr::join(', ', Arr::map(__NAMESPACE__."\ValuesCompiler::render", $items));
+    }
 
-	public static function render(ValuesSQL $item)
-	{
-		$placeholders = array_fill(0, count($item->parameters()), '?');
+    public static function render(ValuesSQL $item)
+    {
+        $placeholders = array_fill(0, count($item->parameters()), '?');
 
-		return '('.join(', ', $placeholders).')';
-	}
+        return '('.join(', ', $placeholders).')';
+    }
 }

--- a/src/DB.php
+++ b/src/DB.php
@@ -39,6 +39,7 @@ class DB extends \PDO
         if ($default_name !== null) {
             static::$default_name = $default_name;
         }
+
         return static::$default_name;
     }
 

--- a/src/DB.php
+++ b/src/DB.php
@@ -12,86 +12,86 @@ use CL\Atlas\Query\DeleteQuery;
  */
 class DB extends \PDO
 {
-	protected static $default_name = 'default';
-	protected static $configurations;
-	protected static $instances;
+    protected static $default_name = 'default';
+    protected static $configurations;
+    protected static $instances;
 
-	public static $defaults = array(
-		'dsn' => 'mysql:dbname=test;host=127.0.0.1',
-		'username' => '',
-		'password' => '',
-		'driver_options' => array(
-			\PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
-		),
-	);
+    public static $defaults = array(
+        'dsn' => 'mysql:dbname=test;host=127.0.0.1',
+        'username' => '',
+        'password' => '',
+        'driver_options' => array(
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+        ),
+    );
 
-	public static function configuration($name, array $parameters = NULL)
-	{
-		if ($parameters === NULL)
-		{
-			return isset(static::$configurations[$name]) ? static::$configurations[$name] : array();
-		}
+    public static function configuration($name, array $parameters = NULL)
+    {
+        if ($parameters === NULL)
+        {
+            return isset(static::$configurations[$name]) ? static::$configurations[$name] : array();
+        }
 
-		static::$configurations[$name] = $parameters;
-	}
+        static::$configurations[$name] = $parameters;
+    }
 
-	public static function defaultName($default_name = NULL)
-	{
-		if ($default_name !== NULL)
-		{
-			static::$default_name = $default_name;
-		}
-		return static::$default_name;
-	}
+    public static function defaultName($default_name = NULL)
+    {
+        if ($default_name !== NULL)
+        {
+            static::$default_name = $default_name;
+        }
+        return static::$default_name;
+    }
 
-	public static function instance($name = NULL)
-	{
-		$name = $name ?: static::defaultName();
+    public static function instance($name = NULL)
+    {
+        $name = $name ?: static::defaultName();
 
-		if ( ! isset(static::$instances[$name]))
-		{
-			$config = static::configuration($name);
+        if ( ! isset(static::$instances[$name]))
+        {
+            $config = static::configuration($name);
 
-			$class = get_called_class();
+            $class = get_called_class();
 
-			static::$instances[$name] = new $class($config);
-		}
+            static::$instances[$name] = new $class($config);
+        }
 
-		return static::$instances[$name];
-	}
+        return static::$instances[$name];
+    }
 
-	public function __construct($options)
-	{
-		$options = array_replace_recursive(static::$defaults, $options);
+    public function __construct($options)
+    {
+        $options = array_replace_recursive(static::$defaults, $options);
 
-		parent::__construct($options['dsn'], $options['username'], $options['password'], $options['driver_options']);
-	}
+        parent::__construct($options['dsn'], $options['username'], $options['password'], $options['driver_options']);
+    }
 
-	public function execute($sql, $parameters)
-	{
-		$statement = $this->prepare($sql);
-		$statement->execute($parameters);
+    public function execute($sql, $parameters)
+    {
+        $statement = $this->prepare($sql);
+        $statement->execute($parameters);
 
-		return $statement;
-	}
+        return $statement;
+    }
 
-	public function select()
-	{
-		return new SelectQuery(NULL, $this);
-	}
+    public function select()
+    {
+        return new SelectQuery(NULL, $this);
+    }
 
-	public function update()
-	{
-		return new UpdateQuery(NULL, $this);
-	}
+    public function update()
+    {
+        return new UpdateQuery(NULL, $this);
+    }
 
-	public function delete()
-	{
-		return new DeleteQuery(NULL, $this);
-	}
+    public function delete()
+    {
+        return new DeleteQuery(NULL, $this);
+    }
 
-	public function insert()
-	{
-		return new InsertQuery(NULL, $this);
-	}
+    public function insert()
+    {
+        return new InsertQuery(NULL, $this);
+    }
 }

--- a/src/DB.php
+++ b/src/DB.php
@@ -27,8 +27,7 @@ class DB extends \PDO
 
     public static function configuration($name, array $parameters = NULL)
     {
-        if ($parameters === NULL)
-        {
+        if ($parameters === NULL) {
             return isset(static::$configurations[$name]) ? static::$configurations[$name] : array();
         }
 
@@ -37,8 +36,7 @@ class DB extends \PDO
 
     public static function defaultName($default_name = NULL)
     {
-        if ($default_name !== NULL)
-        {
+        if ($default_name !== NULL) {
             static::$default_name = $default_name;
         }
         return static::$default_name;
@@ -48,8 +46,7 @@ class DB extends \PDO
     {
         $name = $name ?: static::defaultName();
 
-        if ( ! isset(static::$instances[$name]))
-        {
+        if ( ! isset(static::$instances[$name])) {
             $config = static::configuration($name);
 
             $class = get_called_class();

--- a/src/DB.php
+++ b/src/DB.php
@@ -47,7 +47,7 @@ class DB extends \PDO
     {
         $name = $name ?: static::defaultName();
 
-        if ( ! isset(static::$instances[$name])) {
+        if (! isset(static::$instances[$name])) {
             $config = static::configuration($name);
 
             $class = get_called_class();

--- a/src/DB.php
+++ b/src/DB.php
@@ -25,24 +25,24 @@ class DB extends \PDO
         ),
     );
 
-    public static function configuration($name, array $parameters = NULL)
+    public static function configuration($name, array $parameters = null)
     {
-        if ($parameters === NULL) {
+        if ($parameters === null) {
             return isset(static::$configurations[$name]) ? static::$configurations[$name] : array();
         }
 
         static::$configurations[$name] = $parameters;
     }
 
-    public static function defaultName($default_name = NULL)
+    public static function defaultName($default_name = null)
     {
-        if ($default_name !== NULL) {
+        if ($default_name !== null) {
             static::$default_name = $default_name;
         }
         return static::$default_name;
     }
 
-    public static function instance($name = NULL)
+    public static function instance($name = null)
     {
         $name = $name ?: static::defaultName();
 
@@ -74,21 +74,21 @@ class DB extends \PDO
 
     public function select()
     {
-        return new SelectQuery(NULL, $this);
+        return new SelectQuery(null, $this);
     }
 
     public function update()
     {
-        return new UpdateQuery(NULL, $this);
+        return new UpdateQuery(null, $this);
     }
 
     public function delete()
     {
-        return new DeleteQuery(NULL, $this);
+        return new DeleteQuery(null, $this);
     }
 
     public function insert()
     {
-        return new InsertQuery(NULL, $this);
+        return new InsertQuery(null, $this);
     }
 }

--- a/src/Parametrised.php
+++ b/src/Parametrised.php
@@ -7,6 +7,6 @@
  */
 interface Parametrised {
 
-	public function parameters();
+    public function parameters();
 
 }

--- a/src/Parametrised.php
+++ b/src/Parametrised.php
@@ -5,7 +5,8 @@
  * @copyright  (c) 2014 Clippings Ltd.
  * @license    http://www.opensource.org/licenses/isc-license.txt
  */
-interface Parametrised {
+interface Parametrised
+{
 
     public function parameters();
 

--- a/src/Parametrised.php
+++ b/src/Parametrised.php
@@ -9,5 +9,4 @@ interface Parametrised
 {
 
     public function parameters();
-
 }

--- a/src/Query/DeleteQuery.php
+++ b/src/Query/DeleteQuery.php
@@ -13,54 +13,54 @@ use CL\Atlas\SQL\ConditionSQL;
  */
 class DeleteQuery extends Query
 {
-	public function type($type)
-	{
-		$this->children[Query::TYPE] = $type;
-		return $this;
-	}
+    public function type($type)
+    {
+        $this->children[Query::TYPE] = $type;
+        return $this;
+    }
 
-	public function table($table)
-	{
-		$this->addChildren(Query::TABLE, Arr::toArray($table));
+    public function table($table)
+    {
+        $this->addChildren(Query::TABLE, Arr::toArray($table));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function from($table, $alias = NULL)
-	{
-		$this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
+    public function from($table, $alias = NULL)
+    {
+        $this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function join($table, $condition, $type = NULL)
-	{
-		$this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
-		return $this;
-	}
+    public function join($table, $condition, $type = NULL)
+    {
+        $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+        return $this;
+    }
 
-	public function where($where)
-	{
-		$this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
+    public function where($where)
+    {
+        $this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function order($column, $direction = NULL)
-	{
-		$this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
+    public function order($column, $direction = NULL)
+    {
+        $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function limit($limit)
-	{
-		$this->children[Query::LIMIT] = (int) $limit;
-		return $this;
-	}
+    public function limit($limit)
+    {
+        $this->children[Query::LIMIT] = (int) $limit;
+        return $this;
+    }
 
-	public function sql()
-	{
-		return DeleteCompiler::render($this);
-	}
+    public function sql()
+    {
+        return DeleteCompiler::render($this);
+    }
 }

--- a/src/Query/DeleteQuery.php
+++ b/src/Query/DeleteQuery.php
@@ -16,6 +16,7 @@ class DeleteQuery extends Query
     public function type($type)
     {
         $this->children[Query::TYPE] = $type;
+
         return $this;
     }
 
@@ -36,6 +37,7 @@ class DeleteQuery extends Query
     public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+
         return $this;
     }
 
@@ -56,6 +58,7 @@ class DeleteQuery extends Query
     public function limit($limit)
     {
         $this->children[Query::LIMIT] = (int) $limit;
+
         return $this;
     }
 

--- a/src/Query/DeleteQuery.php
+++ b/src/Query/DeleteQuery.php
@@ -26,14 +26,14 @@ class DeleteQuery extends Query
         return $this;
     }
 
-    public function from($table, $alias = NULL)
+    public function from($table, $alias = null)
     {
         $this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
         return $this;
     }
 
-    public function join($table, $condition, $type = NULL)
+    public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
         return $this;
@@ -46,7 +46,7 @@ class DeleteQuery extends Query
         return $this;
     }
 
-    public function order($column, $direction = NULL)
+    public function order($column, $direction = null)
     {
         $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -15,6 +15,7 @@ class InsertQuery extends Query
     public function type($type)
     {
         $this->children[Query::TYPE] = $type;
+
         return $this;
     }
 
@@ -51,6 +52,7 @@ class InsertQuery extends Query
     public function select(SelectQuery $select)
     {
         $this->children[Query::SELECT] = $select;
+
         return $this;
     }
 

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -12,51 +12,51 @@ use CL\Atlas\SQL\ValuesSQL;
  */
 class InsertQuery extends Query
 {
-	public function type($type)
-	{
-		$this->children[Query::TYPE] = $type;
-		return $this;
-	}
+    public function type($type)
+    {
+        $this->children[Query::TYPE] = $type;
+        return $this;
+    }
 
-	public function into($table)
-	{
-		$this->children[Query::TABLE] = $table;
+    public function into($table)
+    {
+        $this->children[Query::TABLE] = $table;
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function columns($columns)
-	{
-		$this->addChildren(Query::COLUMNS, Arr::toArray($columns));
+    public function columns($columns)
+    {
+        $this->addChildren(Query::COLUMNS, Arr::toArray($columns));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function values(array $values)
-	{
-		$this->children[Query::VALUES] []= new ValuesSQL($values);
+    public function values(array $values)
+    {
+        $this->children[Query::VALUES] []= new ValuesSQL($values);
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function set(array $values)
-	{
-		foreach ($values as $column => $value)
-		{
-			$this->children[Query::SET] []= new SetSQL($column, $value);
-		}
+    public function set(array $values)
+    {
+        foreach ($values as $column => $value)
+        {
+            $this->children[Query::SET] []= new SetSQL($column, $value);
+        }
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function select(SelectQuery $select)
-	{
-		$this->children[Query::SELECT] = $select;
-		return $this;
-	}
+    public function select(SelectQuery $select)
+    {
+        $this->children[Query::SELECT] = $select;
+        return $this;
+    }
 
-	public function sql()
-	{
-		return InsertCompiler::render($this);
-	}
+    public function sql()
+    {
+        return InsertCompiler::render($this);
+    }
 }

--- a/src/Query/InsertQuery.php
+++ b/src/Query/InsertQuery.php
@@ -41,8 +41,7 @@ class InsertQuery extends Query
 
     public function set(array $values)
     {
-        foreach ($values as $column => $value)
-        {
+        foreach ($values as $column => $value) {
             $this->children[Query::SET] []= new SetSQL($column, $value);
         }
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -78,7 +78,7 @@ abstract class Query implements Parametrised {
 
     public function db()
     {
-        if ( ! $this->db) {
+        if (! $this->db) {
             $this->db = DB::instance();
         }
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -12,94 +12,94 @@ use CL\Atlas\Compiler\Compiler;
  */
 abstract class Query implements Parametrised {
 
-	const TYPE     = 1;
-	const TABLE    = 2;
-	const FROM     = 3;
-	const JOIN     = 4;
-	const COLUMNS  = 5;
-	const VALUES   = 6;
-	const SELECT   = 7;
-	const SET      = 8;
-	const WHERE    = 9;
-	const HAVING   = 10;
-	const GROUP_BY = 11;
-	const ORDER_BY = 12;
-	const LIMIT    = 13;
-	const OFFSET   = 14;
+    const TYPE     = 1;
+    const TABLE    = 2;
+    const FROM     = 3;
+    const JOIN     = 4;
+    const COLUMNS  = 5;
+    const VALUES   = 6;
+    const SELECT   = 7;
+    const SET      = 8;
+    const WHERE    = 9;
+    const HAVING   = 10;
+    const GROUP_BY = 11;
+    const ORDER_BY = 12;
+    const LIMIT    = 13;
+    const OFFSET   = 14;
 
-	protected $children;
-	protected $db;
+    protected $children;
+    protected $db;
 
-	public function __construct($children = NULL, DB $db = NULL)
-	{
-		$this->children = $children;
-		$this->db = $db;
-	}
+    public function __construct($children = NULL, DB $db = NULL)
+    {
+        $this->children = $children;
+        $this->db = $db;
+    }
 
-	public function children($index = NULL)
-	{
-		if ($index === NULL)
-		{
-			return $this->children;
-		}
-		else
-		{
-			return isset($this->children[$index]) ? $this->children[$index] : NULL;
-		}
-	}
+    public function children($index = NULL)
+    {
+        if ($index === NULL)
+        {
+            return $this->children;
+        }
+        else
+        {
+            return isset($this->children[$index]) ? $this->children[$index] : NULL;
+        }
+    }
 
-	public function parameters()
-	{
-		$parameters = array();
+    public function parameters()
+    {
+        $parameters = array();
 
-		if ($this->children)
-		{
-			$children = Arr::flatten($this->children);
+        if ($this->children)
+        {
+            $children = Arr::flatten($this->children);
 
-			$parameters = array_map(function($child) {
-				return ($child instanceof Parametrised) ? $child->parameters() : NULL;
-			}, $children);
+            $parameters = array_map(function($child) {
+                return ($child instanceof Parametrised) ? $child->parameters() : NULL;
+            }, $children);
 
-			$parameters = array_values(array_filter(Arr::flatten($parameters)));
-		}
+            $parameters = array_values(array_filter(Arr::flatten($parameters)));
+        }
 
-		return $parameters;
-	}
+        return $parameters;
+    }
 
-	public function addChildren($name, $array)
-	{
-		if ($array)
-		{
-			$this->children[$name] = isset($this->children[$name]) ? array_merge($this->children[$name], $array) : $array;
-		}
-	}
+    public function addChildren($name, $array)
+    {
+        if ($array)
+        {
+            $this->children[$name] = isset($this->children[$name]) ? array_merge($this->children[$name], $array) : $array;
+        }
+    }
 
-	public function addChildrenObjects($name, $array, $argument, $callback)
-	{
-		$objects = Arr::toObjects($array, $argument, $callback);
+    public function addChildrenObjects($name, $array, $argument, $callback)
+    {
+        $objects = Arr::toObjects($array, $argument, $callback);
 
-		$this->addChildren($name, $objects);
-	}
+        $this->addChildren($name, $objects);
+    }
 
-	public function db()
-	{
-		if ( ! $this->db)
-		{
-			$this->db = DB::instance();
-		}
+    public function db()
+    {
+        if ( ! $this->db)
+        {
+            $this->db = DB::instance();
+        }
 
-		return $this->db;
-	}
+        return $this->db;
+    }
 
-	public function execute()
-	{
-		return $this->db()->execute($this->sql(), $this->parameters());
-	}
+    public function execute()
+    {
+        return $this->db()->execute($this->sql(), $this->parameters());
+    }
 
-	public function humanize()
-	{
-		return Compiler::humanize($this->sql(), $this->parameters());
-	}
+    public function humanize()
+    {
+        return Compiler::humanize($this->sql(), $this->parameters());
+    }
 
-	abstract public function sql();
+    abstract public function sql();
 }

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -42,7 +42,9 @@ abstract class Query implements Parametrised
         if ($index === null) {
             return $this->children;
         } else {
-            return isset($this->children[$index]) ? $this->children[$index] : null;
+            return isset($this->children[$index])
+                ? $this->children[$index]
+                : null;
         }
     }
 
@@ -54,7 +56,9 @@ abstract class Query implements Parametrised
             $children = Arr::flatten($this->children);
 
             $parameters = array_map(function ($child) {
-                return ($child instanceof Parametrised) ? $child->parameters() : null;
+                return ($child instanceof Parametrised)
+                    ? $child->parameters()
+                    : null;
             }, $children);
 
             $parameters = array_values(array_filter(Arr::flatten($parameters)));
@@ -66,7 +70,9 @@ abstract class Query implements Parametrised
     public function addChildren($name, $array)
     {
         if ($array) {
-            $this->children[$name] = isset($this->children[$name]) ? array_merge($this->children[$name], $array) : $array;
+            $this->children[$name] = isset($this->children[$name])
+                ? array_merge($this->children[$name], $array)
+                : $array;
         }
     }
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -10,7 +10,8 @@ use CL\Atlas\Compiler\Compiler;
  * @copyright  (c) 2014 Clippings Ltd.
  * @license    http://www.opensource.org/licenses/isc-license.txt
  */
-abstract class Query implements Parametrised {
+abstract class Query implements Parametrised
+{
 
     const TYPE     = 1;
     const TABLE    = 2;

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -52,7 +52,7 @@ abstract class Query implements Parametrised {
         if ($this->children) {
             $children = Arr::flatten($this->children);
 
-            $parameters = array_map(function($child) {
+            $parameters = array_map(function ($child) {
                 return ($child instanceof Parametrised) ? $child->parameters() : null;
             }, $children);
 

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -30,18 +30,18 @@ abstract class Query implements Parametrised {
     protected $children;
     protected $db;
 
-    public function __construct($children = NULL, DB $db = NULL)
+    public function __construct($children = null, DB $db = null)
     {
         $this->children = $children;
         $this->db = $db;
     }
 
-    public function children($index = NULL)
+    public function children($index = null)
     {
-        if ($index === NULL) {
+        if ($index === null) {
             return $this->children;
         } else {
-            return isset($this->children[$index]) ? $this->children[$index] : NULL;
+            return isset($this->children[$index]) ? $this->children[$index] : null;
         }
     }
 
@@ -53,7 +53,7 @@ abstract class Query implements Parametrised {
             $children = Arr::flatten($this->children);
 
             $parameters = array_map(function($child) {
-                return ($child instanceof Parametrised) ? $child->parameters() : NULL;
+                return ($child instanceof Parametrised) ? $child->parameters() : null;
             }, $children);
 
             $parameters = array_values(array_filter(Arr::flatten($parameters)));

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -38,12 +38,9 @@ abstract class Query implements Parametrised {
 
     public function children($index = NULL)
     {
-        if ($index === NULL)
-        {
+        if ($index === NULL) {
             return $this->children;
-        }
-        else
-        {
+        } else {
             return isset($this->children[$index]) ? $this->children[$index] : NULL;
         }
     }
@@ -52,8 +49,7 @@ abstract class Query implements Parametrised {
     {
         $parameters = array();
 
-        if ($this->children)
-        {
+        if ($this->children) {
             $children = Arr::flatten($this->children);
 
             $parameters = array_map(function($child) {
@@ -68,8 +64,7 @@ abstract class Query implements Parametrised {
 
     public function addChildren($name, $array)
     {
-        if ($array)
-        {
+        if ($array) {
             $this->children[$name] = isset($this->children[$name]) ? array_merge($this->children[$name], $array) : $array;
         }
     }
@@ -83,8 +78,7 @@ abstract class Query implements Parametrised {
 
     public function db()
     {
-        if ( ! $this->db)
-        {
+        if ( ! $this->db) {
             $this->db = DB::instance();
         }
 

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -12,74 +12,74 @@ use CL\Atlas\SQL\JoinSQL;
  */
 class SelectQuery extends Query
 {
-	public function type($type)
-	{
-		$this->children[Query::TYPE] = $type;
-		return $this;
-	}
+    public function type($type)
+    {
+        $this->children[Query::TYPE] = $type;
+        return $this;
+    }
 
-	public function columns($column, $alias = NULL)
-	{
-		$this->addChildrenObjects(Query::COLUMNS, $column, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
+    public function columns($column, $alias = NULL)
+    {
+        $this->addChildrenObjects(Query::COLUMNS, $column, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function from($table, $alias = NULL)
-	{
-		$this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
+    public function from($table, $alias = NULL)
+    {
+        $this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function join($table, $condition, $type = NULL)
-	{
-		$this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
-		return $this;
-	}
+    public function join($table, $condition, $type = NULL)
+    {
+        $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+        return $this;
+    }
 
-	public function where($where)
-	{
-		$this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
+    public function where($where)
+    {
+        $this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function group($column, $direction = NULL)
-	{
-		$this->addChildrenObjects(Query::GROUP_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
+    public function group($column, $direction = NULL)
+    {
+        $this->addChildrenObjects(Query::GROUP_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function having($having)
-	{
-		$this->children[Query::HAVING] []= new ConditionSQL($having, array_slice(func_get_args(), 1));
+    public function having($having)
+    {
+        $this->children[Query::HAVING] []= new ConditionSQL($having, array_slice(func_get_args(), 1));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function order($column, $direction = NULL)
-	{
-		$this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
+    public function order($column, $direction = NULL)
+    {
+        $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function limit($limit)
-	{
-		$this->children[Query::LIMIT] = (int) $limit;
-		return $this;
-	}
+    public function limit($limit)
+    {
+        $this->children[Query::LIMIT] = (int) $limit;
+        return $this;
+    }
 
-	public function offset($offset)
-	{
-		$this->children[Query::OFFSET] = (int) $offset;
-		return $this;
-	}
+    public function offset($offset)
+    {
+        $this->children[Query::OFFSET] = (int) $offset;
+        return $this;
+    }
 
-	public function sql()
-	{
-		return SelectCompiler::render($this);
-	}
+    public function sql()
+    {
+        return SelectCompiler::render($this);
+    }
 }

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -15,6 +15,7 @@ class SelectQuery extends Query
     public function type($type)
     {
         $this->children[Query::TYPE] = $type;
+
         return $this;
     }
 
@@ -35,6 +36,7 @@ class SelectQuery extends Query
     public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+
         return $this;
     }
 
@@ -69,12 +71,14 @@ class SelectQuery extends Query
     public function limit($limit)
     {
         $this->children[Query::LIMIT] = (int) $limit;
+
         return $this;
     }
 
     public function offset($offset)
     {
         $this->children[Query::OFFSET] = (int) $offset;
+
         return $this;
     }
 

--- a/src/Query/SelectQuery.php
+++ b/src/Query/SelectQuery.php
@@ -18,21 +18,21 @@ class SelectQuery extends Query
         return $this;
     }
 
-    public function columns($column, $alias = NULL)
+    public function columns($column, $alias = null)
     {
         $this->addChildrenObjects(Query::COLUMNS, $column, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
         return $this;
     }
 
-    public function from($table, $alias = NULL)
+    public function from($table, $alias = null)
     {
         $this->addChildrenObjects(Query::FROM, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
         return $this;
     }
 
-    public function join($table, $condition, $type = NULL)
+    public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
         return $this;
@@ -45,7 +45,7 @@ class SelectQuery extends Query
         return $this;
     }
 
-    public function group($column, $direction = NULL)
+    public function group($column, $direction = null)
     {
         $this->addChildrenObjects(Query::GROUP_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 
@@ -59,7 +59,7 @@ class SelectQuery extends Query
         return $this;
     }
 
-    public function order($column, $direction = NULL)
+    public function order($column, $direction = null)
     {
         $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -34,8 +34,7 @@ class UpdateQuery extends Query
 
     public function set(array $values)
     {
-        foreach ($values as $column => $value)
-        {
+        foreach ($values as $column => $value) {
             $this->children[Query::SET] []= new SetSQL($column, $value);
         }
 

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -16,6 +16,7 @@ class UpdateQuery extends Query
     public function type($type)
     {
         $this->children[Query::TYPE] = $type;
+
         return $this;
     }
 
@@ -29,6 +30,7 @@ class UpdateQuery extends Query
     public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+
         return $this;
     }
 
@@ -58,6 +60,7 @@ class UpdateQuery extends Query
     public function limit($limit)
     {
         $this->children[Query::LIMIT] = (int) $limit;
+
         return $this;
     }
 

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -13,57 +13,57 @@ use CL\Atlas\SQL\SetSQL;
  */
 class UpdateQuery extends Query
 {
-	public function type($type)
-	{
-		$this->children[Query::TYPE] = $type;
-		return $this;
-	}
+    public function type($type)
+    {
+        $this->children[Query::TYPE] = $type;
+        return $this;
+    }
 
-	public function table($table, $alias = NULL)
-	{
-		$this->addChildrenObjects(Query::TABLE, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
+    public function table($table, $alias = NULL)
+    {
+        $this->addChildrenObjects(Query::TABLE, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function join($table, $condition, $type = NULL)
-	{
-		$this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
-		return $this;
-	}
+    public function join($table, $condition, $type = NULL)
+    {
+        $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
+        return $this;
+    }
 
-	public function set(array $values)
-	{
-		foreach ($values as $column => $value)
-		{
-			$this->children[Query::SET] []= new SetSQL($column, $value);
-		}
+    public function set(array $values)
+    {
+        foreach ($values as $column => $value)
+        {
+            $this->children[Query::SET] []= new SetSQL($column, $value);
+        }
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function where($where)
-	{
-		$this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
+    public function where($where)
+    {
+        $this->children[Query::WHERE] []= new ConditionSQL($where, array_slice(func_get_args(), 1));
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function order($column, $direction = NULL)
-	{
-		$this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
+    public function order($column, $direction = NULL)
+    {
+        $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 
-		return $this;
-	}
+        return $this;
+    }
 
-	public function limit($limit)
-	{
-		$this->children[Query::LIMIT] = (int) $limit;
-		return $this;
-	}
+    public function limit($limit)
+    {
+        $this->children[Query::LIMIT] = (int) $limit;
+        return $this;
+    }
 
-	public function sql()
-	{
-		return UpdateCompiler::render($this);
-	}
+    public function sql()
+    {
+        return UpdateCompiler::render($this);
+    }
 }

--- a/src/Query/UpdateQuery.php
+++ b/src/Query/UpdateQuery.php
@@ -19,14 +19,14 @@ class UpdateQuery extends Query
         return $this;
     }
 
-    public function table($table, $alias = NULL)
+    public function table($table, $alias = null)
     {
         $this->addChildrenObjects(Query::TABLE, $table, $alias, 'CL\Atlas\SQL\AliasedSQL::factory');
 
         return $this;
     }
 
-    public function join($table, $condition, $type = NULL)
+    public function join($table, $condition, $type = null)
     {
         $this->children[Query::JOIN] []= new JoinSQL($table, $condition, $type);
         return $this;
@@ -48,7 +48,7 @@ class UpdateQuery extends Query
         return $this;
     }
 
-    public function order($column, $direction = NULL)
+    public function order($column, $direction = null)
     {
         $this->addChildrenObjects(Query::ORDER_BY, $column, $direction, 'CL\Atlas\SQL\DirectionSQL::factory');
 

--- a/src/SQL/AliasedSQL.php
+++ b/src/SQL/AliasedSQL.php
@@ -11,12 +11,12 @@ class AliasedSQL extends SQL
 {
     protected $alias;
 
-    public static function factory($content, $alias = NULL)
+    public static function factory($content, $alias = null)
     {
         return new AliasedSQL($content, $alias);
     }
 
-    function __construct($content, $alias = NULL)
+    function __construct($content, $alias = null)
     {
         $this->content = $content;
         $this->alias = $alias;

--- a/src/SQL/AliasedSQL.php
+++ b/src/SQL/AliasedSQL.php
@@ -16,7 +16,7 @@ class AliasedSQL extends SQL
         return new AliasedSQL($content, $alias);
     }
 
-    function __construct($content, $alias = null)
+    public function __construct($content, $alias = null)
     {
         $this->content = $content;
         $this->alias = $alias;

--- a/src/SQL/AliasedSQL.php
+++ b/src/SQL/AliasedSQL.php
@@ -24,8 +24,7 @@ class AliasedSQL extends SQL
 
     public function parameters()
     {
-        if ($this->content() instanceof Parametrised)
-        {
+        if ($this->content() instanceof Parametrised) {
             return $this->content()->parameters();
         }
     }

--- a/src/SQL/AliasedSQL.php
+++ b/src/SQL/AliasedSQL.php
@@ -9,29 +9,29 @@ use CL\Atlas\Parametrised;
  */
 class AliasedSQL extends SQL
 {
-	protected $alias;
+    protected $alias;
 
-	public static function factory($content, $alias = NULL)
-	{
-		return new AliasedSQL($content, $alias);
-	}
+    public static function factory($content, $alias = NULL)
+    {
+        return new AliasedSQL($content, $alias);
+    }
 
-	function __construct($content, $alias = NULL)
-	{
-		$this->content = $content;
-		$this->alias = $alias;
-	}
+    function __construct($content, $alias = NULL)
+    {
+        $this->content = $content;
+        $this->alias = $alias;
+    }
 
-	public function parameters()
-	{
-		if ($this->content() instanceof Parametrised)
-		{
-			return $this->content()->parameters();
-		}
-	}
+    public function parameters()
+    {
+        if ($this->content() instanceof Parametrised)
+        {
+            return $this->content()->parameters();
+        }
+    }
 
-	public function alias()
-	{
-		return $this->alias;
-	}
+    public function alias()
+    {
+        return $this->alias;
+    }
 }

--- a/src/SQL/ConditionSQL.php
+++ b/src/SQL/ConditionSQL.php
@@ -10,22 +10,15 @@ class ConditionSQL extends SQL
 
     function __construct($content, array $parameters = NULL)
     {
-        if (is_array($content))
-        {
+        if (is_array($content)) {
             $statements = array();
 
-            foreach ($content as $column => $value)
-            {
-                if (is_array($value))
-                {
+            foreach ($content as $column => $value) {
+                if (is_array($value)) {
                     $statements []= "$column IN ?";
-                }
-                elseif (is_null($value))
-                {
+                } elseif (is_null($value)) {
                     $statements []= "$column IS ?";
-                }
-                else
-                {
+                } else {
                     $statements []= "$column = ?";
                 }
 

--- a/src/SQL/ConditionSQL.php
+++ b/src/SQL/ConditionSQL.php
@@ -8,33 +8,33 @@
 class ConditionSQL extends SQL
 {
 
-	function __construct($content, array $parameters = NULL)
-	{
-		if (is_array($content))
-		{
-			$statements = array();
+    function __construct($content, array $parameters = NULL)
+    {
+        if (is_array($content))
+        {
+            $statements = array();
 
-			foreach ($content as $column => $value)
-			{
-				if (is_array($value))
-				{
-					$statements []= "$column IN ?";
-				}
-				elseif (is_null($value))
-				{
-					$statements []= "$column IS ?";
-				}
-				else
-				{
-					$statements []= "$column = ?";
-				}
+            foreach ($content as $column => $value)
+            {
+                if (is_array($value))
+                {
+                    $statements []= "$column IN ?";
+                }
+                elseif (is_null($value))
+                {
+                    $statements []= "$column IS ?";
+                }
+                else
+                {
+                    $statements []= "$column = ?";
+                }
 
-				$parameters []= $value;
-			}
+                $parameters []= $value;
+            }
 
-			$content = implode(' AND ', $statements);
-		}
+            $content = implode(' AND ', $statements);
+        }
 
-		parent::__construct($content, $parameters);
-	}
+        parent::__construct($content, $parameters);
+    }
 }

--- a/src/SQL/ConditionSQL.php
+++ b/src/SQL/ConditionSQL.php
@@ -8,7 +8,7 @@
 class ConditionSQL extends SQL
 {
 
-    function __construct($content, array $parameters = null)
+    public function __construct($content, array $parameters = null)
     {
         if (is_array($content)) {
             $statements = array();

--- a/src/SQL/ConditionSQL.php
+++ b/src/SQL/ConditionSQL.php
@@ -8,7 +8,7 @@
 class ConditionSQL extends SQL
 {
 
-    function __construct($content, array $parameters = NULL)
+    function __construct($content, array $parameters = null)
     {
         if (is_array($content)) {
             $statements = array();

--- a/src/SQL/DirectionSQL.php
+++ b/src/SQL/DirectionSQL.php
@@ -14,7 +14,7 @@ class DirectionSQL extends SQL
         return new DirectionSQL($column, $direction);
     }
 
-    function __construct($column, $direction = null)
+    public function __construct($column, $direction = null)
     {
         $this->direction = $direction;
 

--- a/src/SQL/DirectionSQL.php
+++ b/src/SQL/DirectionSQL.php
@@ -9,12 +9,12 @@ class DirectionSQL extends SQL
 {
     protected $direction;
 
-    public static function factory($column, $direction = NULL)
+    public static function factory($column, $direction = null)
     {
         return new DirectionSQL($column, $direction);
     }
 
-    function __construct($column, $direction = NULL)
+    function __construct($column, $direction = null)
     {
         $this->direction = $direction;
 

--- a/src/SQL/DirectionSQL.php
+++ b/src/SQL/DirectionSQL.php
@@ -7,22 +7,22 @@
  */
 class DirectionSQL extends SQL
 {
-	protected $direction;
+    protected $direction;
 
-	public static function factory($column, $direction = NULL)
-	{
-		return new DirectionSQL($column, $direction);
-	}
+    public static function factory($column, $direction = NULL)
+    {
+        return new DirectionSQL($column, $direction);
+    }
 
-	function __construct($column, $direction = NULL)
-	{
-		$this->direction = $direction;
+    function __construct($column, $direction = NULL)
+    {
+        $this->direction = $direction;
 
-		parent::__construct($column);
-	}
+        parent::__construct($column);
+    }
 
-	public function direction()
-	{
-		return $this->direction;
-	}
+    public function direction()
+    {
+        return $this->direction;
+    }
 }

--- a/src/SQL/JoinSQL.php
+++ b/src/SQL/JoinSQL.php
@@ -7,66 +7,66 @@
  */
 class JoinSQL extends SQL
 {
-	protected $table;
-	protected $condition;
-	protected $type;
+    protected $table;
+    protected $condition;
+    protected $type;
 
-	function __construct($table, $condition, $type = NULL)
-	{
-		if (is_array($condition))
-		{
-			$statements = array();
+    function __construct($table, $condition, $type = NULL)
+    {
+        if (is_array($condition))
+        {
+            $statements = array();
 
-			foreach ($condition as $column => $foreign_column)
-			{
-				$statements [] = "$column = $foreign_column";
-			}
+            foreach ($condition as $column => $foreign_column)
+            {
+                $statements [] = "$column = $foreign_column";
+            }
 
-			$this->condition = 'ON '.join(' AND ', $statements);
-		}
-		else
-		{
-			$this->condition = $condition;
-		}
+            $this->condition = 'ON '.join(' AND ', $statements);
+        }
+        else
+        {
+            $this->condition = $condition;
+        }
 
-		$this->type = $type;
+        $this->type = $type;
 
-		if (is_array($table))
-		{
-			$this->table = new AliasedSQL(key($table), reset($table));
-		}
-		elseif ($table instanceof SQL)
-		{
-			$this->table = $table;
-		}
-		else
-		{
-			$this->table = new AliasedSQL($table);
-		}
-	}
+        if (is_array($table))
+        {
+            $this->table = new AliasedSQL(key($table), reset($table));
+        }
+        elseif ($table instanceof SQL)
+        {
+            $this->table = $table;
+        }
+        else
+        {
+            $this->table = new AliasedSQL($table);
+        }
+    }
 
-	public function table()
-	{
-		return $this->table;
-	}
+    public function table()
+    {
+        return $this->table;
+    }
 
-	public function condition()
-	{
-		return $this->condition;
-	}
+    public function condition()
+    {
+        return $this->condition;
+    }
 
-	public function parameters()
-	{
-		if ($this->condition instanceof SQL)
-		{
-			return $this->condition->parameters();
-		}
+    public function parameters()
+    {
+        if ($this->condition instanceof SQL)
+        {
+            return $this->condition->parameters();
+        }
 
-		return parent::parameters();
-	}
+        return parent::parameters();
+    }
 
-	public function type()
-	{
-		return $this->type;
-	}
+    public function type()
+    {
+        return $this->type;
+    }
 }

--- a/src/SQL/JoinSQL.php
+++ b/src/SQL/JoinSQL.php
@@ -11,7 +11,7 @@ class JoinSQL extends SQL
     protected $condition;
     protected $type;
 
-    function __construct($table, $condition, $type = null)
+    public function __construct($table, $condition, $type = null)
     {
         if (is_array($condition)) {
             $statements = array();

--- a/src/SQL/JoinSQL.php
+++ b/src/SQL/JoinSQL.php
@@ -11,7 +11,7 @@ class JoinSQL extends SQL
     protected $condition;
     protected $type;
 
-    function __construct($table, $condition, $type = NULL)
+    function __construct($table, $condition, $type = null)
     {
         if (is_array($condition)) {
             $statements = array();

--- a/src/SQL/JoinSQL.php
+++ b/src/SQL/JoinSQL.php
@@ -13,34 +13,25 @@ class JoinSQL extends SQL
 
     function __construct($table, $condition, $type = NULL)
     {
-        if (is_array($condition))
-        {
+        if (is_array($condition)) {
             $statements = array();
 
-            foreach ($condition as $column => $foreign_column)
-            {
+            foreach ($condition as $column => $foreign_column) {
                 $statements [] = "$column = $foreign_column";
             }
 
             $this->condition = 'ON '.join(' AND ', $statements);
-        }
-        else
-        {
+        } else {
             $this->condition = $condition;
         }
 
         $this->type = $type;
 
-        if (is_array($table))
-        {
+        if (is_array($table)) {
             $this->table = new AliasedSQL(key($table), reset($table));
-        }
-        elseif ($table instanceof SQL)
-        {
+        } elseif ($table instanceof SQL) {
             $this->table = $table;
-        }
-        else
-        {
+        } else {
             $this->table = new AliasedSQL($table);
         }
     }
@@ -57,8 +48,7 @@ class JoinSQL extends SQL
 
     public function parameters()
     {
-        if ($this->condition instanceof SQL)
-        {
+        if ($this->condition instanceof SQL) {
             return $this->condition->parameters();
         }
 

--- a/src/SQL/SQL.php
+++ b/src/SQL/SQL.php
@@ -7,7 +7,8 @@ use CL\Atlas\Parametrised;
  * @copyright  (c) 2014 Clippings Ltd.
  * @license    http://www.opensource.org/licenses/isc-license.txt
  */
-class SQL implements Parametrised {
+class SQL implements Parametrised
+{
 
     protected $parameters;
     protected $content;

--- a/src/SQL/SQL.php
+++ b/src/SQL/SQL.php
@@ -12,7 +12,7 @@ class SQL implements Parametrised {
     protected $parameters;
     protected $content;
 
-    function __construct($content, array $parameters = NULL)
+    function __construct($content, array $parameters = null)
     {
         $this->content = (string) $content;
 

--- a/src/SQL/SQL.php
+++ b/src/SQL/SQL.php
@@ -13,7 +13,7 @@ class SQL implements Parametrised
     protected $parameters;
     protected $content;
 
-    function __construct($content, array $parameters = null)
+    public function __construct($content, array $parameters = null)
     {
         $this->content = (string) $content;
 

--- a/src/SQL/SQL.php
+++ b/src/SQL/SQL.php
@@ -9,31 +9,31 @@ use CL\Atlas\Parametrised;
  */
 class SQL implements Parametrised {
 
-	protected $parameters;
-	protected $content;
+    protected $parameters;
+    protected $content;
 
-	function __construct($content, array $parameters = NULL)
-	{
-		$this->content = (string) $content;
+    function __construct($content, array $parameters = NULL)
+    {
+        $this->content = (string) $content;
 
-		if ($parameters)
-		{
-			$this->parameters = $parameters;
-		}
-	}
+        if ($parameters)
+        {
+            $this->parameters = $parameters;
+        }
+    }
 
-	public function __toString()
-	{
-		return $this->content();
-	}
+    public function __toString()
+    {
+        return $this->content();
+    }
 
-	public function content()
-	{
-		return $this->content;
-	}
+    public function content()
+    {
+        return $this->content;
+    }
 
-	public function parameters()
-	{
-		return $this->parameters;
-	}
+    public function parameters()
+    {
+        return $this->parameters;
+    }
 }

--- a/src/SQL/SQL.php
+++ b/src/SQL/SQL.php
@@ -16,8 +16,7 @@ class SQL implements Parametrised {
     {
         $this->content = (string) $content;
 
-        if ($parameters)
-        {
+        if ($parameters) {
             $this->parameters = $parameters;
         }
     }

--- a/src/SQL/SetSQL.php
+++ b/src/SQL/SetSQL.php
@@ -11,7 +11,7 @@ class SetSQL extends SQL
 {
     protected $value;
 
-    function __construct($column, $value)
+    public function __construct($column, $value)
     {
         $this->value = $value;
         parent::__construct($column);

--- a/src/SQL/SetSQL.php
+++ b/src/SQL/SetSQL.php
@@ -19,8 +19,7 @@ class SetSQL extends SQL
 
     public function parameters()
     {
-        if ($this->value() instanceof Parametrised)
-        {
+        if ($this->value() instanceof Parametrised) {
             return $this->value()->parameters();
         }
 

--- a/src/SQL/SetSQL.php
+++ b/src/SQL/SetSQL.php
@@ -9,26 +9,26 @@ use CL\Atlas\Parametrised;
  */
 class SetSQL extends SQL
 {
-	protected $value;
+    protected $value;
 
-	function __construct($column, $value)
-	{
-		$this->value = $value;
-		parent::__construct($column);
-	}
+    function __construct($column, $value)
+    {
+        $this->value = $value;
+        parent::__construct($column);
+    }
 
-	public function parameters()
-	{
-		if ($this->value() instanceof Parametrised)
-		{
-			return $this->value()->parameters();
-		}
+    public function parameters()
+    {
+        if ($this->value() instanceof Parametrised)
+        {
+            return $this->value()->parameters();
+        }
 
-		return array($this->value);
-	}
+        return array($this->value);
+    }
 
-	public function value()
-	{
-		return $this->value;
-	}
+    public function value()
+    {
+        return $this->value;
+    }
 }

--- a/src/SQL/ValuesSQL.php
+++ b/src/SQL/ValuesSQL.php
@@ -9,6 +9,6 @@ class ValuesSQL extends SQL
 {
     function __construct(array $values)
     {
-        parent::__construct(NULL, $values);
+        parent::__construct(null, $values);
     }
 }

--- a/src/SQL/ValuesSQL.php
+++ b/src/SQL/ValuesSQL.php
@@ -7,8 +7,8 @@
  */
 class ValuesSQL extends SQL
 {
-	function __construct(array $values)
-	{
-		parent::__construct(NULL, $values);
-	}
+    function __construct(array $values)
+    {
+        parent::__construct(NULL, $values);
+    }
 }

--- a/src/SQL/ValuesSQL.php
+++ b/src/SQL/ValuesSQL.php
@@ -7,7 +7,7 @@
  */
 class ValuesSQL extends SQL
 {
-    function __construct(array $values)
+    public function __construct(array $values)
     {
         parent::__construct(null, $values);
     }

--- a/src/Str.php
+++ b/src/Str.php
@@ -11,12 +11,12 @@ namespace CL\Atlas;
  */
 class Str
 {
-	public static function replace($pattern, array $replacements, $subject)
-	{
-		$current = 0;
+    public static function replace($pattern, array $replacements, $subject)
+    {
+        $current = 0;
 
-		return preg_replace_callback($pattern, function() use ($replacements, & $current) {
-			return $replacements[$current++];
-		}, $subject);
-	}
+        return preg_replace_callback($pattern, function() use ($replacements, & $current) {
+            return $replacements[$current++];
+        }, $subject);
+    }
 }

--- a/src/Str.php
+++ b/src/Str.php
@@ -15,7 +15,7 @@ class Str
     {
         $current = 0;
 
-        return preg_replace_callback($pattern, function() use ($replacements, & $current) {
+        return preg_replace_callback($pattern, function () use ($replacements, & $current) {
             return $replacements[$current++];
         }, $subject);
     }

--- a/tests/src/AbstractTestCase.php
+++ b/tests/src/AbstractTestCase.php
@@ -9,31 +9,31 @@ use CL\Atlas\DB;
  */
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase {
 
-	public $env;
+    public $env;
 
-	public function setUp()
-	{
-		parent::setUp();
+    public function setUp()
+    {
+        parent::setUp();
 
-		$this->env = new EB\Environment(array(
-			'static' => new EB\Environment_Group_Static,
-		));
+        $this->env = new EB\Environment(array(
+            'static' => new EB\Environment_Group_Static,
+        ));
 
-		DB::configuration('default', array(
-			'class' => 'DB_Test',
-			'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
-			'username' => 'root',
-		));
+        DB::configuration('default', array(
+            'class' => 'DB_Test',
+            'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
+            'username' => 'root',
+        ));
 
-		$this->env->backup_and_set(array(
-			'CL\Atlas\DB::$instances' => array(),
-		));
-	}
+        $this->env->backup_and_set(array(
+            'CL\Atlas\DB::$instances' => array(),
+        ));
+    }
 
-	public function tearDown()
-	{
-		$this->env->restore();
+    public function tearDown()
+    {
+        $this->env->restore();
 
-		parent::tearDown();
-	}
+        parent::tearDown();
+    }
 }

--- a/tests/src/AbstractTestCase.php
+++ b/tests/src/AbstractTestCase.php
@@ -7,7 +7,8 @@ use CL\Atlas\DB;
  * @package Jam
  * @author Ivan Kerin
  */
-abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase {
+abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
+{
 
     public $env;
 

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -77,10 +77,8 @@ class ArrTest extends AbstractTestCase {
         $object = $this->getMock('stdClass', array('callback'));
 
         $index = 0;
-        foreach ($expected as $value)
-        {
-            if ( ! is_object($value))
-            {
+        foreach ($expected as $value) {
+            if ( ! is_object($value)) {
                 $object
                     ->expects($this->at($index++))
                     ->method('callback')

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -78,7 +78,7 @@ class ArrTest extends AbstractTestCase {
 
         $index = 0;
         foreach ($expected as $value) {
-            if ( ! is_object($value)) {
+            if (! is_object($value)) {
                 $object
                     ->expects($this->at($index++))
                     ->method('callback')

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -94,8 +94,8 @@ class ArrTest extends AbstractTestCase {
     public function dataMap()
     {
         return array(
-            array(array('name1', 'name2'), function($item){ return $item.'2';}, array('name12', 'name22')),
-            array(null, function($item){ return $item.'2';}, null),
+            array(array('name1', 'name2'), function ($item){ return $item.'2';}, array('name12', 'name22')),
+            array(null, function ($item){ return $item.'2';}, null),
         );
     }
 

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -95,8 +95,12 @@ class ArrTest extends AbstractTestCase
     public function dataMap()
     {
         return array(
-            array(array('name1', 'name2'), function ($item){ return $item.'2';}, array('name12', 'name22')),
-            array(null, function ($item){ return $item.'2';}, null),
+            array(array('name1', 'name2'), function ($item) {
+                return $item.'2';
+            }, array('name12', 'name22')),
+            array(null, function ($item) {
+                return $item.'2';
+            }, null),
         );
     }
 

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -91,7 +91,6 @@ class ArrTest extends AbstractTestCase
         $this->assertEquals($expected, Arr::toObjects($array, $argument, array($object, 'callback')));
     }
 
-
     public function dataMap()
     {
         return array(

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -14,9 +14,9 @@ class ArrTest extends AbstractTestCase {
     public function dataToAssoc()
     {
         return array(
-            array(array('name1', 'name2'), array('name1' => NULL, 'name2' => NULL)),
-            array(array('name1', 'name2' => 'val2'), array('name1' => NULL, 'name2' => 'val2')),
-            array(array('name1', 'name2' => new stdClass), array('name1' => NULL, 'name2' => new stdClass)),
+            array(array('name1', 'name2'), array('name1' => null, 'name2' => null)),
+            array(array('name1', 'name2' => 'val2'), array('name1' => null, 'name2' => 'val2')),
+            array(array('name1', 'name2' => new stdClass), array('name1' => null, 'name2' => new stdClass)),
         );
     }
 
@@ -50,8 +50,8 @@ class ArrTest extends AbstractTestCase {
 
     public function dataToObjects()
     {
-        $test1 = array('test1', NULL);
-        $test2 = array('test2', NULL);
+        $test1 = array('test1', null);
+        $test2 = array('test2', null);
         $alias1 = array('test1', 'alias1');
         $alias2 = array('test2', 'alias2');
         $alias3 = array(new SelectQuery, 'alias3');
@@ -60,11 +60,11 @@ class ArrTest extends AbstractTestCase {
         return array(
             array('test1', 'alias1', array($alias1)),
             array(new SelectQuery, 'alias3', array($alias3)),
-            array('test1', NULL, array($test1)),
-            array(array('test1'), NULL, array($test1)),
-            array(array('test1', 'test2'), NULL, array($test1, $test2)),
-            array(array('test1', 'test2' => 'alias2'), NULL, array($test1, $alias2)),
-            array(array('test1', 'test2' => 'alias2', $sql_alias), NULL, array($test1, $alias2, $sql_alias)),
+            array('test1', null, array($test1)),
+            array(array('test1'), null, array($test1)),
+            array(array('test1', 'test2'), null, array($test1, $test2)),
+            array(array('test1', 'test2' => 'alias2'), null, array($test1, $alias2)),
+            array(array('test1', 'test2' => 'alias2', $sql_alias), null, array($test1, $alias2, $sql_alias)),
         );
     }
 
@@ -95,7 +95,7 @@ class ArrTest extends AbstractTestCase {
     {
         return array(
             array(array('name1', 'name2'), function($item){ return $item.'2';}, array('name12', 'name22')),
-            array(NULL, function($item){ return $item.'2';}, NULL),
+            array(null, function($item){ return $item.'2';}, null),
         );
     }
 
@@ -112,7 +112,7 @@ class ArrTest extends AbstractTestCase {
     {
         return array(
             array('|', array('name1', 'name2', 'name3'), 'name1|name2|name3'),
-            array('|', NULL, NULL),
+            array('|', null, null),
         );
     }
 

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -9,7 +9,8 @@ use stdClass;
 /**
  * @group arr
  */
-class ArrTest extends AbstractTestCase {
+class ArrTest extends AbstractTestCase
+{
 
     public function dataToAssoc()
     {

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -128,9 +128,22 @@ class ArrTest extends AbstractTestCase
     public function dataFlatten()
     {
         return array(
-            array(array('name1' => 'test1', 'name2' => 'test2'), array('name1' => 'test1', 'name2' => 'test2')),
-            array(array('name1', 'name2'), array('name1', 'name2')),
-            array(array('name1', 'name2', array('test1', 'test2', array('part1'), 'test3')), array('name1', 'name2', 'test1', 'test2', 'part1', 'test3')),
+            array(
+                array('name1' => 'test1', 'name2' => 'test2'),
+                array('name1' => 'test1', 'name2' => 'test2')
+            ),
+            array(
+                array('name1', 'name2'),
+                array('name1', 'name2')
+            ),
+            array(
+                array(
+                    'name1',
+                    'name2',
+                    array('test1', 'test2', array('part1'), 'test3')
+                ),
+                array('name1', 'name2', 'test1', 'test2', 'part1', 'test3')
+            ),
         );
     }
 

--- a/tests/src/ArrTest.php
+++ b/tests/src/ArrTest.php
@@ -11,136 +11,136 @@ use stdClass;
  */
 class ArrTest extends AbstractTestCase {
 
-	public function dataToAssoc()
-	{
-		return array(
-			array(array('name1', 'name2'), array('name1' => NULL, 'name2' => NULL)),
-			array(array('name1', 'name2' => 'val2'), array('name1' => NULL, 'name2' => 'val2')),
-			array(array('name1', 'name2' => new stdClass), array('name1' => NULL, 'name2' => new stdClass)),
-		);
-	}
+    public function dataToAssoc()
+    {
+        return array(
+            array(array('name1', 'name2'), array('name1' => NULL, 'name2' => NULL)),
+            array(array('name1', 'name2' => 'val2'), array('name1' => NULL, 'name2' => 'val2')),
+            array(array('name1', 'name2' => new stdClass), array('name1' => NULL, 'name2' => new stdClass)),
+        );
+    }
 
-	/**
-	 * @dataProvider dataToAssoc
-	 * @covers CL\Atlas\Arr::toAssoc
-	 */
-	public function testToAssoc($array, $expected)
-	{
-		$this->assertEquals($expected, Arr::toAssoc($array));
-	}
+    /**
+     * @dataProvider dataToAssoc
+     * @covers CL\Atlas\Arr::toAssoc
+     */
+    public function testToAssoc($array, $expected)
+    {
+        $this->assertEquals($expected, Arr::toAssoc($array));
+    }
 
-	public function dataToArray()
-	{
-		return array(
-			array(array('name1', 'name2'), array('name1', 'name2')),
-			array(array('name1'), array('name1')),
-			array('name1', array('name1')),
-			array(new stdClass, array(new stdClass)),
-		);
-	}
+    public function dataToArray()
+    {
+        return array(
+            array(array('name1', 'name2'), array('name1', 'name2')),
+            array(array('name1'), array('name1')),
+            array('name1', array('name1')),
+            array(new stdClass, array(new stdClass)),
+        );
+    }
 
-	/**
-	 * @dataProvider dataToArray
-	 * @covers CL\Atlas\Arr::toArray
-	 */
-	public function testToArray($array, $expected)
-	{
-		$this->assertEquals($expected, Arr::toArray($array));
-	}
+    /**
+     * @dataProvider dataToArray
+     * @covers CL\Atlas\Arr::toArray
+     */
+    public function testToArray($array, $expected)
+    {
+        $this->assertEquals($expected, Arr::toArray($array));
+    }
 
-	public function dataToObjects()
-	{
-		$test1 = array('test1', NULL);
-		$test2 = array('test2', NULL);
-		$alias1 = array('test1', 'alias1');
-		$alias2 = array('test2', 'alias2');
-		$alias3 = array(new SelectQuery, 'alias3');
-		$sql_alias = new AliasedSQL('test3', 'alias3');
+    public function dataToObjects()
+    {
+        $test1 = array('test1', NULL);
+        $test2 = array('test2', NULL);
+        $alias1 = array('test1', 'alias1');
+        $alias2 = array('test2', 'alias2');
+        $alias3 = array(new SelectQuery, 'alias3');
+        $sql_alias = new AliasedSQL('test3', 'alias3');
 
-		return array(
-			array('test1', 'alias1', array($alias1)),
-			array(new SelectQuery, 'alias3', array($alias3)),
-			array('test1', NULL, array($test1)),
-			array(array('test1'), NULL, array($test1)),
-			array(array('test1', 'test2'), NULL, array($test1, $test2)),
-			array(array('test1', 'test2' => 'alias2'), NULL, array($test1, $alias2)),
-			array(array('test1', 'test2' => 'alias2', $sql_alias), NULL, array($test1, $alias2, $sql_alias)),
-		);
-	}
+        return array(
+            array('test1', 'alias1', array($alias1)),
+            array(new SelectQuery, 'alias3', array($alias3)),
+            array('test1', NULL, array($test1)),
+            array(array('test1'), NULL, array($test1)),
+            array(array('test1', 'test2'), NULL, array($test1, $test2)),
+            array(array('test1', 'test2' => 'alias2'), NULL, array($test1, $alias2)),
+            array(array('test1', 'test2' => 'alias2', $sql_alias), NULL, array($test1, $alias2, $sql_alias)),
+        );
+    }
 
-	/**
-	 * @dataProvider dataToObjects
-	 * @covers CL\Atlas\Arr::toObjects
-	 */
-	public function testToObjects($array, $argument, array $expected)
-	{
-		$object = $this->getMock('stdClass', array('callback'));
+    /**
+     * @dataProvider dataToObjects
+     * @covers CL\Atlas\Arr::toObjects
+     */
+    public function testToObjects($array, $argument, array $expected)
+    {
+        $object = $this->getMock('stdClass', array('callback'));
 
-		$index = 0;
-		foreach ($expected as $value)
-		{
-			if ( ! is_object($value))
-			{
-				$object
-					->expects($this->at($index++))
-					->method('callback')
-					->with($this->equalTo($value[0]), $this->equalTo($value[1]))
-					->will($this->returnValue($value));
-			}
-		}
+        $index = 0;
+        foreach ($expected as $value)
+        {
+            if ( ! is_object($value))
+            {
+                $object
+                    ->expects($this->at($index++))
+                    ->method('callback')
+                    ->with($this->equalTo($value[0]), $this->equalTo($value[1]))
+                    ->will($this->returnValue($value));
+            }
+        }
 
-		$this->assertEquals($expected, Arr::toObjects($array, $argument, array($object, 'callback')));
-	}
+        $this->assertEquals($expected, Arr::toObjects($array, $argument, array($object, 'callback')));
+    }
 
 
-	public function dataMap()
-	{
-		return array(
-			array(array('name1', 'name2'), function($item){ return $item.'2';}, array('name12', 'name22')),
-			array(NULL, function($item){ return $item.'2';}, NULL),
-		);
-	}
+    public function dataMap()
+    {
+        return array(
+            array(array('name1', 'name2'), function($item){ return $item.'2';}, array('name12', 'name22')),
+            array(NULL, function($item){ return $item.'2';}, NULL),
+        );
+    }
 
-	/**
-	 * @dataProvider dataMap
-	 * @covers CL\Atlas\Arr::map
-	 */
-	public function testMap($array, $collection, $expected)
-	{
-		$this->assertEquals($expected, Arr::map($collection, $array));
-	}
+    /**
+     * @dataProvider dataMap
+     * @covers CL\Atlas\Arr::map
+     */
+    public function testMap($array, $collection, $expected)
+    {
+        $this->assertEquals($expected, Arr::map($collection, $array));
+    }
 
-	public function dataJoin()
-	{
-		return array(
-			array('|', array('name1', 'name2', 'name3'), 'name1|name2|name3'),
-			array('|', NULL, NULL),
-		);
-	}
+    public function dataJoin()
+    {
+        return array(
+            array('|', array('name1', 'name2', 'name3'), 'name1|name2|name3'),
+            array('|', NULL, NULL),
+        );
+    }
 
-	/**
-	 * @dataProvider dataJoin
-	 * @covers CL\Atlas\Arr::join
-	 */
-	public function testJoin($separator, $array, $expected)
-	{
-		$this->assertEquals($expected, Arr::join($separator, $array));
-	}
-	public function dataFlatten()
-	{
-		return array(
-			array(array('name1' => 'test1', 'name2' => 'test2'), array('name1' => 'test1', 'name2' => 'test2')),
-			array(array('name1', 'name2'), array('name1', 'name2')),
-			array(array('name1', 'name2', array('test1', 'test2', array('part1'), 'test3')), array('name1', 'name2', 'test1', 'test2', 'part1', 'test3')),
-		);
-	}
+    /**
+     * @dataProvider dataJoin
+     * @covers CL\Atlas\Arr::join
+     */
+    public function testJoin($separator, $array, $expected)
+    {
+        $this->assertEquals($expected, Arr::join($separator, $array));
+    }
+    public function dataFlatten()
+    {
+        return array(
+            array(array('name1' => 'test1', 'name2' => 'test2'), array('name1' => 'test1', 'name2' => 'test2')),
+            array(array('name1', 'name2'), array('name1', 'name2')),
+            array(array('name1', 'name2', array('test1', 'test2', array('part1'), 'test3')), array('name1', 'name2', 'test1', 'test2', 'part1', 'test3')),
+        );
+    }
 
-	/**
-	 * @dataProvider dataFlatten
-	 * @covers CL\Atlas\Arr::flatten
-	 */
-	public function testFlatten($array, $expected)
-	{
-		$this->assertEquals($expected, Arr::flatten($array));
-	}
+    /**
+     * @dataProvider dataFlatten
+     * @covers CL\Atlas\Arr::flatten
+     */
+    public function testFlatten($array, $expected)
+    {
+        $this->assertEquals($expected, Arr::flatten($array));
+    }
 }

--- a/tests/src/Compiler/AliasedCompilerTest.php
+++ b/tests/src/Compiler/AliasedCompilerTest.php
@@ -9,7 +9,8 @@ use CL\Atlas\Query\SelectQuery;
  * @group compiler
  * @group compiler.aliased
  */
-class AliasedCompilerTest extends AbstractTestCase {
+class AliasedCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\AliasedCompiler::combine

--- a/tests/src/Compiler/AliasedCompilerTest.php
+++ b/tests/src/Compiler/AliasedCompilerTest.php
@@ -31,9 +31,9 @@ class AliasedCompilerTest extends AbstractTestCase {
 
         return array(
             array('table1', 'alias1', 'table1 AS alias1'),
-            array('table1', NULL, 'table1'),
+            array('table1', null, 'table1'),
             array($query, 'alias1', '(SELECT * FROM table2 LIMIT 1) AS alias1'),
-            array($query, NULL, '(SELECT * FROM table2 LIMIT 1)'),
+            array($query, null, '(SELECT * FROM table2 LIMIT 1)'),
         );
     }
     /**

--- a/tests/src/Compiler/AliasedCompilerTest.php
+++ b/tests/src/Compiler/AliasedCompilerTest.php
@@ -11,39 +11,39 @@ use CL\Atlas\Query\SelectQuery;
  */
 class AliasedCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\AliasedCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$alias1 = new AliasedSQL('table1', 'alias1');
-		$alias2 = new AliasedSQL('table2', 'alias2');
+    /**
+     * @covers CL\Atlas\Compiler\AliasedCompiler::combine
+     */
+    public function testCombine()
+    {
+        $alias1 = new AliasedSQL('table1', 'alias1');
+        $alias2 = new AliasedSQL('table2', 'alias2');
 
-		$this->assertEquals('table1 AS alias1, table2 AS alias2', AliasedCompiler::combine(array($alias1, $alias2)));
-	}
+        $this->assertEquals('table1 AS alias1, table2 AS alias2', AliasedCompiler::combine(array($alias1, $alias2)));
+    }
 
-	public function dataRender()
-	{
-		$query = new SelectQuery();
-		$query
-			->from('table2')
-			->limit(1);
+    public function dataRender()
+    {
+        $query = new SelectQuery();
+        $query
+            ->from('table2')
+            ->limit(1);
 
-		return array(
-			array('table1', 'alias1', 'table1 AS alias1'),
-			array('table1', NULL, 'table1'),
-			array($query, 'alias1', '(SELECT * FROM table2 LIMIT 1) AS alias1'),
-			array($query, NULL, '(SELECT * FROM table2 LIMIT 1)'),
-		);
-	}
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\AliasedCompiler::render
-	 */
-	public function testRender($content, $alias, $expected)
-	{
-		$aliased = new AliasedSQL($content, $alias);
+        return array(
+            array('table1', 'alias1', 'table1 AS alias1'),
+            array('table1', NULL, 'table1'),
+            array($query, 'alias1', '(SELECT * FROM table2 LIMIT 1) AS alias1'),
+            array($query, NULL, '(SELECT * FROM table2 LIMIT 1)'),
+        );
+    }
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\AliasedCompiler::render
+     */
+    public function testRender($content, $alias, $expected)
+    {
+        $aliased = new AliasedSQL($content, $alias);
 
-		$this->assertEquals($expected, AliasedCompiler::render($aliased));
-	}
+        $this->assertEquals($expected, AliasedCompiler::render($aliased));
+    }
 }

--- a/tests/src/Compiler/CompilerTest.php
+++ b/tests/src/Compiler/CompilerTest.php
@@ -29,8 +29,8 @@ class CompilerTest extends AbstractTestCase {
     public function dataExpression()
     {
         return array(
-            array(array('SELECT', '*', NULL, 'WHERE i = 1'), 'SELECT * WHERE i = 1'),
-            array(array(NULL, NULL, NULL), NULL),
+            array(array('SELECT', '*', null, 'WHERE i = 1'), 'SELECT * WHERE i = 1'),
+            array(array(null, null, null), null),
             array(array('DELETE', 'FROM test'), 'DELETE FROM test'),
         );
     }
@@ -47,7 +47,7 @@ class CompilerTest extends AbstractTestCase {
     public function dataWord()
     {
         return array(
-            array('SELECT', NULL, NULL),
+            array('SELECT', null, null),
             array('FROM', 'table', 'FROM table'),
         );
     }
@@ -65,7 +65,7 @@ class CompilerTest extends AbstractTestCase {
     {
         return array(
             array('SELECT test', '(SELECT test)'),
-            array(NULL, NULL),
+            array(null, null),
         );
     }
 
@@ -83,8 +83,8 @@ class CompilerTest extends AbstractTestCase {
         return array(
             array('SELECT test', array(), 'SELECT test'),
             array('SELECT test FROM table1 WHERE name = ?', array('param'), 'SELECT test FROM table1 WHERE name = "param"'),
-            array('SELECT test FROM table1 WHERE name = ? AND id IS ?', array('param', NULL), 'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'),
-            array('SELECT test FROM table1 WHERE name = ? AND id IS NOT ?', array(10, NULL), 'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'),
+            array('SELECT test FROM table1 WHERE name = ? AND id IS ?', array('param', null), 'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'),
+            array('SELECT test FROM table1 WHERE name = ? AND id IS NOT ?', array(10, null), 'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'),
         );
     }
 

--- a/tests/src/Compiler/CompilerTest.php
+++ b/tests/src/Compiler/CompilerTest.php
@@ -8,92 +8,92 @@ use CL\Atlas\Compiler\Compiler;
  */
 class CompilerTest extends AbstractTestCase {
 
-	public function dataToPlaceholders()
-	{
-		return array(
-			array(array('name1', 'name2'), '(?, ?)'),
-			array(array(), '()'),
-			array(array(1, 2, 3, 4), '(?, ?, ?, ?)'),
-		);
-	}
+    public function dataToPlaceholders()
+    {
+        return array(
+            array(array('name1', 'name2'), '(?, ?)'),
+            array(array(), '()'),
+            array(array(1, 2, 3, 4), '(?, ?, ?, ?)'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataToPlaceholders
-	 * @covers CL\Atlas\Compiler\Compiler::toPlaceholders
-	 */
-	public function testToPlaceholders($array, $expected)
-	{
-		$this->assertEquals($expected, Compiler::toPlaceholders($array));
-	}
+    /**
+     * @dataProvider dataToPlaceholders
+     * @covers CL\Atlas\Compiler\Compiler::toPlaceholders
+     */
+    public function testToPlaceholders($array, $expected)
+    {
+        $this->assertEquals($expected, Compiler::toPlaceholders($array));
+    }
 
-	public function dataExpression()
-	{
-		return array(
-			array(array('SELECT', '*', NULL, 'WHERE i = 1'), 'SELECT * WHERE i = 1'),
-			array(array(NULL, NULL, NULL), NULL),
-			array(array('DELETE', 'FROM test'), 'DELETE FROM test'),
-		);
-	}
+    public function dataExpression()
+    {
+        return array(
+            array(array('SELECT', '*', NULL, 'WHERE i = 1'), 'SELECT * WHERE i = 1'),
+            array(array(NULL, NULL, NULL), NULL),
+            array(array('DELETE', 'FROM test'), 'DELETE FROM test'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataExpression
-	 * @covers CL\Atlas\Compiler\Compiler::expression
-	 */
-	public function testExpression($array, $expected)
-	{
-		$this->assertEquals($expected, Compiler::expression($array));
-	}
+    /**
+     * @dataProvider dataExpression
+     * @covers CL\Atlas\Compiler\Compiler::expression
+     */
+    public function testExpression($array, $expected)
+    {
+        $this->assertEquals($expected, Compiler::expression($array));
+    }
 
-	public function dataWord()
-	{
-		return array(
-			array('SELECT', NULL, NULL),
-			array('FROM', 'table', 'FROM table'),
-		);
-	}
+    public function dataWord()
+    {
+        return array(
+            array('SELECT', NULL, NULL),
+            array('FROM', 'table', 'FROM table'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataWord
-	 * @covers CL\Atlas\Compiler\Compiler::word
-	 */
-	public function testWord($word, $statement, $expected)
-	{
-		$this->assertEquals($expected, Compiler::word($word, $statement));
-	}
+    /**
+     * @dataProvider dataWord
+     * @covers CL\Atlas\Compiler\Compiler::word
+     */
+    public function testWord($word, $statement, $expected)
+    {
+        $this->assertEquals($expected, Compiler::word($word, $statement));
+    }
 
-	public function dataBraced()
-	{
-		return array(
-			array('SELECT test', '(SELECT test)'),
-			array(NULL, NULL),
-		);
-	}
+    public function dataBraced()
+    {
+        return array(
+            array('SELECT test', '(SELECT test)'),
+            array(NULL, NULL),
+        );
+    }
 
-	/**
-	 * @dataProvider dataBraced
-	 * @covers CL\Atlas\Compiler\Compiler::braced
-	 */
-	public function testBraced($statement, $expected)
-	{
-		$this->assertEquals($expected, Compiler::braced($statement));
-	}
+    /**
+     * @dataProvider dataBraced
+     * @covers CL\Atlas\Compiler\Compiler::braced
+     */
+    public function testBraced($statement, $expected)
+    {
+        $this->assertEquals($expected, Compiler::braced($statement));
+    }
 
-	public function dataHumanize()
-	{
-		return array(
-			array('SELECT test', array(), 'SELECT test'),
-			array('SELECT test FROM table1 WHERE name = ?', array('param'), 'SELECT test FROM table1 WHERE name = "param"'),
-			array('SELECT test FROM table1 WHERE name = ? AND id IS ?', array('param', NULL), 'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'),
-			array('SELECT test FROM table1 WHERE name = ? AND id IS NOT ?', array(10, NULL), 'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'),
-		);
-	}
+    public function dataHumanize()
+    {
+        return array(
+            array('SELECT test', array(), 'SELECT test'),
+            array('SELECT test FROM table1 WHERE name = ?', array('param'), 'SELECT test FROM table1 WHERE name = "param"'),
+            array('SELECT test FROM table1 WHERE name = ? AND id IS ?', array('param', NULL), 'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'),
+            array('SELECT test FROM table1 WHERE name = ? AND id IS NOT ?', array(10, NULL), 'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataHumanize
-	 * @covers CL\Atlas\Compiler\Compiler::humanize
-	 */
-	public function testHumanize($statement, $parameters, $expected)
-	{
-		$this->assertEquals($expected, Compiler::humanize($statement, $parameters));
-	}
+    /**
+     * @dataProvider dataHumanize
+     * @covers CL\Atlas\Compiler\Compiler::humanize
+     */
+    public function testHumanize($statement, $parameters, $expected)
+    {
+        $this->assertEquals($expected, Compiler::humanize($statement, $parameters));
+    }
 }

--- a/tests/src/Compiler/CompilerTest.php
+++ b/tests/src/Compiler/CompilerTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\Compiler\Compiler;
 /**
  * @group compiler
  */
-class CompilerTest extends AbstractTestCase {
+class CompilerTest extends AbstractTestCase
+{
 
     public function dataToPlaceholders()
     {

--- a/tests/src/Compiler/CompilerTest.php
+++ b/tests/src/Compiler/CompilerTest.php
@@ -82,10 +82,26 @@ class CompilerTest extends AbstractTestCase
     public function dataHumanize()
     {
         return array(
-            array('SELECT test', array(), 'SELECT test'),
-            array('SELECT test FROM table1 WHERE name = ?', array('param'), 'SELECT test FROM table1 WHERE name = "param"'),
-            array('SELECT test FROM table1 WHERE name = ? AND id IS ?', array('param', null), 'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'),
-            array('SELECT test FROM table1 WHERE name = ? AND id IS NOT ?', array(10, null), 'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'),
+            array(
+                'SELECT test',
+                array(),
+                'SELECT test'
+            ),
+            array(
+                'SELECT test FROM table1 WHERE name = ?',
+                array('param'),
+                'SELECT test FROM table1 WHERE name = "param"'
+            ),
+            array(
+                'SELECT test FROM table1 WHERE name = ? AND id IS ?',
+                array('param', null),
+                'SELECT test FROM table1 WHERE name = "param" AND id IS NULL'
+            ),
+            array(
+                'SELECT test FROM table1 WHERE name = ? AND id IS NOT ?',
+                array(10, null),
+                'SELECT test FROM table1 WHERE name = 10 AND id IS NOT NULL'
+            ),
         );
     }
 

--- a/tests/src/Compiler/ConditionCompilerTest.php
+++ b/tests/src/Compiler/ConditionCompilerTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\ConditionSQL;
  * @group compiler
  * @group compiler.condition
  */
-class ConditionCompilerTest extends AbstractTestCase {
+class ConditionCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\ConditionCompiler::combine

--- a/tests/src/Compiler/ConditionCompilerTest.php
+++ b/tests/src/Compiler/ConditionCompilerTest.php
@@ -10,32 +10,32 @@ use CL\Atlas\SQL\ConditionSQL;
  */
 class ConditionCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\ConditionCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$condition1 = new ConditionSQL('name = ?', array(2));
-		$condition2 = new ConditionSQL('param = ?', array(3));
+    /**
+     * @covers CL\Atlas\Compiler\ConditionCompiler::combine
+     */
+    public function testCombine()
+    {
+        $condition1 = new ConditionSQL('name = ?', array(2));
+        $condition2 = new ConditionSQL('param = ?', array(3));
 
-		$this->assertEquals('(name = ?) AND (param = ?)', ConditionCompiler::combine(array($condition1, $condition2)));
-	}
+        $this->assertEquals('(name = ?) AND (param = ?)', ConditionCompiler::combine(array($condition1, $condition2)));
+    }
 
-	public function dataRender()
-	{
-		return array(
-			array('name = ?', array(10), 'name = ?'),
-			array('name IN ?', array(array(10, 15)), 'name IN (?, ?)'),
-		);
-	}
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\ConditionCompiler::render
-	 */
-	public function testRender($content, $parameters, $expected)
-	{
-		$condition = new ConditionSQL($content, $parameters);
+    public function dataRender()
+    {
+        return array(
+            array('name = ?', array(10), 'name = ?'),
+            array('name IN ?', array(array(10, 15)), 'name IN (?, ?)'),
+        );
+    }
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\ConditionCompiler::render
+     */
+    public function testRender($content, $parameters, $expected)
+    {
+        $condition = new ConditionSQL($content, $parameters);
 
-		$this->assertEquals($expected, ConditionCompiler::render($condition));
-	}
+        $this->assertEquals($expected, ConditionCompiler::render($condition));
+    }
 }

--- a/tests/src/Compiler/DeleteCompilerTest.php
+++ b/tests/src/Compiler/DeleteCompilerTest.php
@@ -12,38 +12,38 @@ use CL\Atlas\SQL\SQL;
 class DeleteCompilerTest extends AbstractTestCase {
 
 
-	/**
-	 * @covers CL\Atlas\Compiler\DeleteCompiler::render
-	 */
-	public function testRender()
-	{
-		$delete = new DeleteQuery;
-		$delete
-			->table(array('table1', 'alias1'))
-			->from(array('table1', 'table2' => 'alias1', 'table3'))
-			->join(array('join1' => 'alias_join1'), array('col' => 'col2'))
-			->limit(10)
-			->where(array('test' => 'value'))
-			->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
-			->where('type > ? AND type < ? OR base IN ?', '10', '20', array('1', '2', '3'));
+    /**
+     * @covers CL\Atlas\Compiler\DeleteCompiler::render
+     */
+    public function testRender()
+    {
+        $delete = new DeleteQuery;
+        $delete
+            ->table(array('table1', 'alias1'))
+            ->from(array('table1', 'table2' => 'alias1', 'table3'))
+            ->join(array('join1' => 'alias_join1'), array('col' => 'col2'))
+            ->limit(10)
+            ->where(array('test' => 'value'))
+            ->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
+            ->where('type > ? AND type < ? OR base IN ?', '10', '20', array('1', '2', '3'));
 
-		$expected_sql = <<<SQL
+        $expected_sql = <<<SQL
 DELETE table1, alias1 FROM table1, table2 AS alias1, table3 JOIN join1 AS alias_join1 ON col = col2 WHERE (test = ?) AND (test_statement = IF ("test", ?, ?)) AND (type > ? AND type < ? OR base IN (?, ?, ?)) LIMIT 10
 SQL;
 
-		$this->assertEquals($expected_sql, DeleteCompiler::render($delete));
+        $this->assertEquals($expected_sql, DeleteCompiler::render($delete));
 
-		$expected_parameters = array(
-			'value',
-			'val1',
-			'val2',
-			'10',
-			'20',
-			'1',
-			'2',
-			'3',
-		);
+        $expected_parameters = array(
+            'value',
+            'val1',
+            'val2',
+            '10',
+            '20',
+            '1',
+            '2',
+            '3',
+        );
 
-		$this->assertEquals($expected_parameters, $delete->parameters());
-	}
+        $this->assertEquals($expected_parameters, $delete->parameters());
+    }
 }

--- a/tests/src/Compiler/DeleteCompilerTest.php
+++ b/tests/src/Compiler/DeleteCompilerTest.php
@@ -9,7 +9,8 @@ use CL\Atlas\SQL\SQL;
  * @group compiler
  * @group compiler.delete
  */
-class DeleteCompilerTest extends AbstractTestCase {
+class DeleteCompilerTest extends AbstractTestCase
+{
 
 
     /**

--- a/tests/src/Compiler/DirectionCompilerTest.php
+++ b/tests/src/Compiler/DirectionCompilerTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\DirectionSQL;
  * @group compiler
  * @group compiler.direction
  */
-class DirectionCompilerTest extends AbstractTestCase {
+class DirectionCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\DirectionCompiler::combine

--- a/tests/src/Compiler/DirectionCompilerTest.php
+++ b/tests/src/Compiler/DirectionCompilerTest.php
@@ -10,32 +10,32 @@ use CL\Atlas\SQL\DirectionSQL;
  */
 class DirectionCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\DirectionCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$direction1 = new DirectionSQL('name', 'ASC');
-		$direction2 = new DirectionSQL('param', 'DESC');
+    /**
+     * @covers CL\Atlas\Compiler\DirectionCompiler::combine
+     */
+    public function testCombine()
+    {
+        $direction1 = new DirectionSQL('name', 'ASC');
+        $direction2 = new DirectionSQL('param', 'DESC');
 
-		$this->assertEquals('name ASC, param DESC', DirectionCompiler::combine(array($direction1, $direction2)));
-	}
+        $this->assertEquals('name ASC, param DESC', DirectionCompiler::combine(array($direction1, $direction2)));
+    }
 
-	public function dataRender()
-	{
-		return array(
-			array('name', 'ASC', 'name ASC'),
-			array('name', NULL, 'name'),
-		);
-	}
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\DirectionCompiler::render
-	 */
-	public function testRender($content, $parameters, $expected)
-	{
-		$direction = new DirectionSQL($content, $parameters);
+    public function dataRender()
+    {
+        return array(
+            array('name', 'ASC', 'name ASC'),
+            array('name', NULL, 'name'),
+        );
+    }
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\DirectionCompiler::render
+     */
+    public function testRender($content, $parameters, $expected)
+    {
+        $direction = new DirectionSQL($content, $parameters);
 
-		$this->assertEquals($expected, DirectionCompiler::render($direction));
-	}
+        $this->assertEquals($expected, DirectionCompiler::render($direction));
+    }
 }

--- a/tests/src/Compiler/DirectionCompilerTest.php
+++ b/tests/src/Compiler/DirectionCompilerTest.php
@@ -25,7 +25,7 @@ class DirectionCompilerTest extends AbstractTestCase {
     {
         return array(
             array('name', 'ASC', 'name ASC'),
-            array('name', NULL, 'name'),
+            array('name', null, 'name'),
         );
     }
     /**

--- a/tests/src/Compiler/InsertCompilerTest.php
+++ b/tests/src/Compiler/InsertCompilerTest.php
@@ -10,7 +10,8 @@ use CL\Atlas\SQL\SQL;
  * @group compiler
  * @group compiler.insert
  */
-class InsertCompilerTest extends AbstractTestCase {
+class InsertCompilerTest extends AbstractTestCase
+{
 
 
     public function dataInsert()

--- a/tests/src/Compiler/InsertCompilerTest.php
+++ b/tests/src/Compiler/InsertCompilerTest.php
@@ -13,67 +13,67 @@ use CL\Atlas\SQL\SQL;
 class InsertCompilerTest extends AbstractTestCase {
 
 
-	public function dataInsert()
-	{
-		$rows = array();
-		$args = array();
+    public function dataInsert()
+    {
+        $rows = array();
+        $args = array();
 
-		// ROW 1
-		// --------------------
+        // ROW 1
+        // --------------------
 
-		$args[0] = new InsertQuery;
-		$args[0]
-			->type('IGNORE')
-			->into('table1')
-			->set(array('name' => 10, 'email' => 'email@example.com'));
+        $args[0] = new InsertQuery;
+        $args[0]
+            ->type('IGNORE')
+            ->into('table1')
+            ->set(array('name' => 10, 'email' => 'email@example.com'));
 
-		$args[1] = <<<SQL
+        $args[1] = <<<SQL
 INSERT IGNORE INTO table1 SET name = ?, email = ?
 SQL;
-		$rows[] = $args;
+        $rows[] = $args;
 
 
-		// ROW 2
-		// --------------------
-		$select = new SelectQuery;
-		$select
-			->from('table2')
-			->where(array('name' => '10'));
+        // ROW 2
+        // --------------------
+        $select = new SelectQuery;
+        $select
+            ->from('table2')
+            ->where(array('name' => '10'));
 
-		$args[0] = new InsertQuery;
-		$args[0]
-			->into('table1')
-			->columns(array('id', 'name'))
-			->select($select);
+        $args[0] = new InsertQuery;
+        $args[0]
+            ->into('table1')
+            ->columns(array('id', 'name'))
+            ->select($select);
 
-		$args[1] = <<<SQL
+        $args[1] = <<<SQL
 INSERT INTO table1 (id, name) SELECT * FROM table2 WHERE (name = ?)
 SQL;
-		$rows[] = $args;
+        $rows[] = $args;
 
-		// ROW 3
-		// --------------------
-		$args[0] = new InsertQuery;
-		$args[0]
-			->into('table1')
-			->columns(array('id', 'name'))
-			->values(array(1, 'name1'))
-			->values(array(2, 'name2'));
+        // ROW 3
+        // --------------------
+        $args[0] = new InsertQuery;
+        $args[0]
+            ->into('table1')
+            ->columns(array('id', 'name'))
+            ->values(array(1, 'name1'))
+            ->values(array(2, 'name2'));
 
-		$args[1] = <<<SQL
+        $args[1] = <<<SQL
 INSERT INTO table1 (id, name) VALUES (?, ?), (?, ?)
 SQL;
-		$rows[] = $args;
+        $rows[] = $args;
 
-		return $rows;
-	}
+        return $rows;
+    }
 
-	/**
-	 * @covers CL\Atlas\Compiler\InsertCompiler::render
-	 * @dataProvider dataInsert
-	 */
-	public function testInsert($query, $expected_sql)
-	{
-		$this->assertEquals($expected_sql, InsertCompiler::render($query));
-	}
+    /**
+     * @covers CL\Atlas\Compiler\InsertCompiler::render
+     * @dataProvider dataInsert
+     */
+    public function testInsert($query, $expected_sql)
+    {
+        $this->assertEquals($expected_sql, InsertCompiler::render($query));
+    }
 }

--- a/tests/src/Compiler/JoinCompilerTest.php
+++ b/tests/src/Compiler/JoinCompilerTest.php
@@ -24,8 +24,8 @@ class JoinCompilerTest extends AbstractTestCase {
     public function dataRender()
     {
         return array(
-            array('table', array('col' => 'col_foreign'), NULL, 'JOIN table ON col = col_foreign'),
-            array('table', array('col' => 'col_foreign', 'is_deleted' => TRUE), NULL, 'JOIN table ON col = col_foreign AND is_deleted = 1'),
+            array('table', array('col' => 'col_foreign'), null, 'JOIN table ON col = col_foreign'),
+            array('table', array('col' => 'col_foreign', 'is_deleted' => true), null, 'JOIN table ON col = col_foreign AND is_deleted = 1'),
             array(array('table' => 'alias1'), 'USING (col)', 'INNER', 'INNER JOIN table AS alias1 USING (col)'),
         );
     }

--- a/tests/src/Compiler/JoinCompilerTest.php
+++ b/tests/src/Compiler/JoinCompilerTest.php
@@ -19,15 +19,33 @@ class JoinCompilerTest extends AbstractTestCase
         $join1 = new JoinSQL('table', 'USING (col1)');
         $join2 = new JoinSQL('table2', array('col1' => 'col2'));
 
-        $this->assertEquals('JOIN table USING (col1) JOIN table2 ON col1 = col2', JoinCompiler::combine(array($join1, $join2)));
+        $this->assertEquals(
+            'JOIN table USING (col1) JOIN table2 ON col1 = col2',
+            JoinCompiler::combine(array($join1, $join2))
+        );
     }
 
     public function dataRender()
     {
         return array(
-            array('table', array('col' => 'col_foreign'), null, 'JOIN table ON col = col_foreign'),
-            array('table', array('col' => 'col_foreign', 'is_deleted' => true), null, 'JOIN table ON col = col_foreign AND is_deleted = 1'),
-            array(array('table' => 'alias1'), 'USING (col)', 'INNER', 'INNER JOIN table AS alias1 USING (col)'),
+            array(
+                'table',
+                array('col' => 'col_foreign'),
+                null,
+                'JOIN table ON col = col_foreign'
+            ),
+            array(
+                'table',
+                array('col' => 'col_foreign', 'is_deleted' => true),
+                null,
+                'JOIN table ON col = col_foreign AND is_deleted = 1'
+            ),
+            array(
+                array('table' => 'alias1'),
+                'USING (col)',
+                'INNER',
+                'INNER JOIN table AS alias1 USING (col)'
+            ),
         );
     }
     /**

--- a/tests/src/Compiler/JoinCompilerTest.php
+++ b/tests/src/Compiler/JoinCompilerTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\JoinSQL;
  * @group compiler
  * @group compiler.join
  */
-class JoinCompilerTest extends AbstractTestCase {
+class JoinCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\JoinCompiler::combine

--- a/tests/src/Compiler/JoinCompilerTest.php
+++ b/tests/src/Compiler/JoinCompilerTest.php
@@ -10,33 +10,33 @@ use CL\Atlas\SQL\JoinSQL;
  */
 class JoinCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\JoinCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$join1 = new JoinSQL('table', 'USING (col1)');
-		$join2 = new JoinSQL('table2', array('col1' => 'col2'));
+    /**
+     * @covers CL\Atlas\Compiler\JoinCompiler::combine
+     */
+    public function testCombine()
+    {
+        $join1 = new JoinSQL('table', 'USING (col1)');
+        $join2 = new JoinSQL('table2', array('col1' => 'col2'));
 
-		$this->assertEquals('JOIN table USING (col1) JOIN table2 ON col1 = col2', JoinCompiler::combine(array($join1, $join2)));
-	}
+        $this->assertEquals('JOIN table USING (col1) JOIN table2 ON col1 = col2', JoinCompiler::combine(array($join1, $join2)));
+    }
 
-	public function dataRender()
-	{
-		return array(
-			array('table', array('col' => 'col_foreign'), NULL, 'JOIN table ON col = col_foreign'),
-			array('table', array('col' => 'col_foreign', 'is_deleted' => TRUE), NULL, 'JOIN table ON col = col_foreign AND is_deleted = 1'),
-			array(array('table' => 'alias1'), 'USING (col)', 'INNER', 'INNER JOIN table AS alias1 USING (col)'),
-		);
-	}
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\JoinCompiler::render
-	 */
-	public function testRender($table, $condition, $type, $expected)
-	{
-		$join = new JoinSQL($table, $condition, $type);
+    public function dataRender()
+    {
+        return array(
+            array('table', array('col' => 'col_foreign'), NULL, 'JOIN table ON col = col_foreign'),
+            array('table', array('col' => 'col_foreign', 'is_deleted' => TRUE), NULL, 'JOIN table ON col = col_foreign AND is_deleted = 1'),
+            array(array('table' => 'alias1'), 'USING (col)', 'INNER', 'INNER JOIN table AS alias1 USING (col)'),
+        );
+    }
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\JoinCompiler::render
+     */
+    public function testRender($table, $condition, $type, $expected)
+    {
+        $join = new JoinSQL($table, $condition, $type);
 
-		$this->assertEquals($expected, JoinCompiler::render($join));
-	}
+        $this->assertEquals($expected, JoinCompiler::render($join));
+    }
 }

--- a/tests/src/Compiler/SelectCompilerTest.php
+++ b/tests/src/Compiler/SelectCompilerTest.php
@@ -11,59 +11,59 @@ use CL\Atlas\SQL\SQL;
  */
 class SelectCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\SelectCompiler::render
-	 */
-	public function testCompile()
-	{
-		$select2 = new SelectQuery;
-		$select2
-			->from('one')
-			->type('DISTINCT')
-			->join('table1', new SQL('USING (col1, col2)'))
-			->where(array('name' => 'small'));
+    /**
+     * @covers CL\Atlas\Compiler\SelectCompiler::render
+     */
+    public function testCompile()
+    {
+        $select2 = new SelectQuery;
+        $select2
+            ->from('one')
+            ->type('DISTINCT')
+            ->join('table1', new SQL('USING (col1, col2)'))
+            ->where(array('name' => 'small'));
 
-		$select = new SelectQuery;
-		$select
-			->from(array('bigtable', 'smalltable' => 'alias'))
-			->from($select2, 'select_alias')
-			->columns(array('col1', 'col3' => 'alias_col'))
-			->where(array('test' => 'value'))
-			->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
-			->join('table2', array('col1' => 'col2'))
-			->where('type > ? AND type < ? AND base IN ?', 10, 20, array('1', '2', '3'))
-			->having(array('test' => 'value2'))
-			->having('type > ? AND base IN ?', 20, array('5', '6', '7'))
-			->limit(10)
-			->offset(8)
-			->order('type', 'ASC')
-			->order('base')
-			->group('base', 'ASC')
-			->group('type');
+        $select = new SelectQuery;
+        $select
+            ->from(array('bigtable', 'smalltable' => 'alias'))
+            ->from($select2, 'select_alias')
+            ->columns(array('col1', 'col3' => 'alias_col'))
+            ->where(array('test' => 'value'))
+            ->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
+            ->join('table2', array('col1' => 'col2'))
+            ->where('type > ? AND type < ? AND base IN ?', 10, 20, array('1', '2', '3'))
+            ->having(array('test' => 'value2'))
+            ->having('type > ? AND base IN ?', 20, array('5', '6', '7'))
+            ->limit(10)
+            ->offset(8)
+            ->order('type', 'ASC')
+            ->order('base')
+            ->group('base', 'ASC')
+            ->group('type');
 
-		$expected_sql = <<<SQL
+        $expected_sql = <<<SQL
 SELECT col1, col3 AS alias_col FROM bigtable, smalltable AS alias, (SELECT DISTINCT * FROM one JOIN table1 USING (col1, col2) WHERE (name = ?)) AS select_alias JOIN table2 ON col1 = col2 WHERE (test = ?) AND (test_statement = IF ("test", ?, ?)) AND (type > ? AND type < ? AND base IN (?, ?, ?)) GROUP BY base ASC, type HAVING (test = ?) AND (type > ? AND base IN (?, ?, ?)) ORDER BY type ASC, base LIMIT 10 OFFSET 8
 SQL;
 
-		$this->assertEquals($expected_sql, SelectCompiler::render($select));
+        $this->assertEquals($expected_sql, SelectCompiler::render($select));
 
-		$expected_parameters = array(
-			'small',
-			'value',
-			'val1',
-			'val2',
-			'10',
-			'20',
-			'1',
-			'2',
-			'3',
-			'value2',
-			'20',
-			'5',
-			'6',
-			'7',
-		);
+        $expected_parameters = array(
+            'small',
+            'value',
+            'val1',
+            'val2',
+            '10',
+            '20',
+            '1',
+            '2',
+            '3',
+            'value2',
+            '20',
+            '5',
+            '6',
+            '7',
+        );
 
-		$this->assertEquals($expected_parameters, $select->parameters());
-	}
+        $this->assertEquals($expected_parameters, $select->parameters());
+    }
 }

--- a/tests/src/Compiler/SelectCompilerTest.php
+++ b/tests/src/Compiler/SelectCompilerTest.php
@@ -9,7 +9,8 @@ use CL\Atlas\SQL\SQL;
  * @group compiler
  * @group compiler.select
  */
-class SelectCompilerTest extends AbstractTestCase {
+class SelectCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\SelectCompiler::render

--- a/tests/src/Compiler/SetCompilerTest.php
+++ b/tests/src/Compiler/SetCompilerTest.php
@@ -12,39 +12,39 @@ use CL\Atlas\SQL\SQL;
  */
 class SetCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\SetCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$set1 = new SetSQL('name1', 'param1');
-		$set2 = new SetSQL('name2', 'param2');
+    /**
+     * @covers CL\Atlas\Compiler\SetCompiler::combine
+     */
+    public function testCombine()
+    {
+        $set1 = new SetSQL('name1', 'param1');
+        $set2 = new SetSQL('name2', 'param2');
 
-		$this->assertEquals('name1 = ?, name2 = ?', SetCompiler::combine(array($set1, $set2)));
-	}
+        $this->assertEquals('name1 = ?, name2 = ?', SetCompiler::combine(array($set1, $set2)));
+    }
 
-	public function dataRender()
-	{
-		$query = new SelectQuery();
-		$query->from('table1')->where(array('name' => 'Peter'));
+    public function dataRender()
+    {
+        $query = new SelectQuery();
+        $query->from('table1')->where(array('name' => 'Peter'));
 
-		$sql = new SQL('IF(name = "test", "big", "samll")');
+        $sql = new SQL('IF(name = "test", "big", "samll")');
 
-		return array(
-			array('name', 'param1', 'name = ?'),
-			array('name', $query, 'name = (SELECT * FROM table1 WHERE (name = ?))'),
-			array('name', $sql, 'name = IF(name = "test", "big", "samll")'),
-		);
-	}
+        return array(
+            array('name', 'param1', 'name = ?'),
+            array('name', $query, 'name = (SELECT * FROM table1 WHERE (name = ?))'),
+            array('name', $sql, 'name = IF(name = "test", "big", "samll")'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\SetCompiler::render
-	 */
-	public function testRender($name, $value, $expected)
-	{
-		$set = new SetSQL($name, $value);
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\SetCompiler::render
+     */
+    public function testRender($name, $value, $expected)
+    {
+        $set = new SetSQL($name, $value);
 
-		$this->assertEquals($expected, SetCompiler::render($set));
-	}
+        $this->assertEquals($expected, SetCompiler::render($set));
+    }
 }

--- a/tests/src/Compiler/SetCompilerTest.php
+++ b/tests/src/Compiler/SetCompilerTest.php
@@ -10,7 +10,8 @@ use CL\Atlas\SQL\SQL;
  * @group compiler
  * @group compiler.set
  */
-class SetCompilerTest extends AbstractTestCase {
+class SetCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\SetCompiler::combine

--- a/tests/src/Compiler/UpdateCompilerTest.php
+++ b/tests/src/Compiler/UpdateCompilerTest.php
@@ -11,42 +11,42 @@ use CL\Atlas\SQL\SQL;
  */
 class UpdateCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\UpdateCompiler::render
-	 */
-	public function testUpdate()
-	{
+    /**
+     * @covers CL\Atlas\Compiler\UpdateCompiler::render
+     */
+    public function testUpdate()
+    {
 
-		$update = new UpdateQuery;
-		$update
-			->type('IGNORE')
-			->table(array('table1', 'table2' => 'alias1'))
-			->join(array('join1' => 'alias_join1'), array('col' => 'col2'))
-			->set(array('post' => 'new value', 'name' => new SQL('IF ("test", ?, ?)', array('val3', 'val4'))))
-			->limit(10)
-			->where(array('test' => 'value'))
-			->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
-			->where('type > ? AND type < ? OR base IN ?', 10, 20, array('1', '2', '3'));
+        $update = new UpdateQuery;
+        $update
+            ->type('IGNORE')
+            ->table(array('table1', 'table2' => 'alias1'))
+            ->join(array('join1' => 'alias_join1'), array('col' => 'col2'))
+            ->set(array('post' => 'new value', 'name' => new SQL('IF ("test", ?, ?)', array('val3', 'val4'))))
+            ->limit(10)
+            ->where(array('test' => 'value'))
+            ->where('test_statement = IF ("test", ?, ?)', 'val1', 'val2')
+            ->where('type > ? AND type < ? OR base IN ?', 10, 20, array('1', '2', '3'));
 
-		$expected_sql = <<<SQL
+        $expected_sql = <<<SQL
 UPDATE IGNORE table1, table2 AS alias1 JOIN join1 AS alias_join1 ON col = col2 SET post = ?, name = IF ("test", ?, ?) WHERE (test = ?) AND (test_statement = IF ("test", ?, ?)) AND (type > ? AND type < ? OR base IN (?, ?, ?)) LIMIT 10
 SQL;
-		$this->assertEquals($expected_sql, UpdateCompiler::render($update));
+        $this->assertEquals($expected_sql, UpdateCompiler::render($update));
 
-		$expected_parameters = array(
-			'new value',
-			'val3',
-			'val4',
-			'value',
-			'val1',
-			'val2',
-			'10',
-			'20',
-			'1',
-			'2',
-			'3',
-		);
+        $expected_parameters = array(
+            'new value',
+            'val3',
+            'val4',
+            'value',
+            'val1',
+            'val2',
+            '10',
+            '20',
+            '1',
+            '2',
+            '3',
+        );
 
-		$this->assertEquals($expected_parameters, $update->parameters());
-	}
+        $this->assertEquals($expected_parameters, $update->parameters());
+    }
 }

--- a/tests/src/Compiler/UpdateCompilerTest.php
+++ b/tests/src/Compiler/UpdateCompilerTest.php
@@ -9,7 +9,8 @@ use CL\Atlas\SQL\SQL;
  * @group compiler
  * @group compiler.update
  */
-class UpdateCompilerTest extends AbstractTestCase {
+class UpdateCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\UpdateCompiler::render

--- a/tests/src/Compiler/ValuesCompilerTest.php
+++ b/tests/src/Compiler/ValuesCompilerTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\ValuesSQL;
  * @group compiler
  * @group compiler.values
  */
-class ValuesCompilerTest extends AbstractTestCase {
+class ValuesCompilerTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Compiler\ValuesCompiler::combine

--- a/tests/src/Compiler/ValuesCompilerTest.php
+++ b/tests/src/Compiler/ValuesCompilerTest.php
@@ -10,34 +10,34 @@ use CL\Atlas\SQL\ValuesSQL;
  */
 class ValuesCompilerTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Compiler\ValuesCompiler::combine
-	 */
-	public function testCombine()
-	{
-		$values1 = new ValuesSQL(array('var1', 'var2'));
-		$values2 = new ValuesSQL(array('var3', 'var4'));
+    /**
+     * @covers CL\Atlas\Compiler\ValuesCompiler::combine
+     */
+    public function testCombine()
+    {
+        $values1 = new ValuesSQL(array('var1', 'var2'));
+        $values2 = new ValuesSQL(array('var3', 'var4'));
 
-		$this->assertEquals('(?, ?), (?, ?)', ValuesCompiler::combine(array($values1, $values2)));
-	}
+        $this->assertEquals('(?, ?), (?, ?)', ValuesCompiler::combine(array($values1, $values2)));
+    }
 
-	public function dataRender()
-	{
-		return array(
-			array(array('var1'), '(?)'),
-			array(array('var1', 'var2'), '(?, ?)'),
-			array(array('var1', 'var2', 'var3'), '(?, ?, ?)'),
-		);
-	}
+    public function dataRender()
+    {
+        return array(
+            array(array('var1'), '(?)'),
+            array(array('var1', 'var2'), '(?, ?)'),
+            array(array('var1', 'var2', 'var3'), '(?, ?, ?)'),
+        );
+    }
 
-	/**
-	 * @dataProvider dataRender
-	 * @covers CL\Atlas\Compiler\ValuesCompiler::render
-	 */
-	public function testRender($values, $expected)
-	{
-		$values = new ValuesSQL($values);
+    /**
+     * @dataProvider dataRender
+     * @covers CL\Atlas\Compiler\ValuesCompiler::render
+     */
+    public function testRender($values, $expected)
+    {
+        $values = new ValuesSQL($values);
 
-		$this->assertEquals($expected, ValuesCompiler::render($values));
-	}
+        $this->assertEquals($expected, ValuesCompiler::render($values));
+    }
 }

--- a/tests/src/DBTest.php
+++ b/tests/src/DBTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\DB;
 /**
  * @group compiler
  */
-class DBTest extends AbstractTestCase {
+class DBTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\DB::configuration

--- a/tests/src/DBTest.php
+++ b/tests/src/DBTest.php
@@ -8,132 +8,132 @@ use CL\Atlas\DB;
  */
 class DBTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\DB::configuration
-	 */
-	public function testConfiguration()
-	{
-		$this->env->backup_and_set(array(
-			'CL\Atlas\DB::$configurations' => array(),
-		));
+    /**
+     * @covers CL\Atlas\DB::configuration
+     */
+    public function testConfiguration()
+    {
+        $this->env->backup_and_set(array(
+            'CL\Atlas\DB::$configurations' => array(),
+        ));
 
-		$config = array('some', 'test');
+        $config = array('some', 'test');
 
-		DB::configuration('test', $config);
+        DB::configuration('test', $config);
 
-		$this->assertSame($config, DB::configuration('test'));
-	}
+        $this->assertSame($config, DB::configuration('test'));
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::defaultName
-	 */
-	public function testDefaultName()
-	{
-		$this->assertEquals('default', DB::defaultName());
+    /**
+     * @covers CL\Atlas\DB::defaultName
+     */
+    public function testDefaultName()
+    {
+        $this->assertEquals('default', DB::defaultName());
 
-		$this->env->backup_and_set(array(
-			'CL\Atlas\DB::$default_name' => 'test',
-		));
+        $this->env->backup_and_set(array(
+            'CL\Atlas\DB::$default_name' => 'test',
+        ));
 
-		$this->assertEquals('test', DB::defaultName());
-		DB::defaultName('default_test');
-		$this->assertEquals('default_test', DB::defaultName());
-	}
+        $this->assertEquals('test', DB::defaultName());
+        DB::defaultName('default_test');
+        $this->assertEquals('default_test', DB::defaultName());
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::instance
-	 * @covers CL\Atlas\DB::__construct
-	 */
-	public function testInstance()
-	{
-		DB::configuration('default', array(
-			'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
-			'username' => 'root',
-		));
+    /**
+     * @covers CL\Atlas\DB::instance
+     * @covers CL\Atlas\DB::__construct
+     */
+    public function testInstance()
+    {
+        DB::configuration('default', array(
+            'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
+            'username' => 'root',
+        ));
 
-		DB::configuration('test', array(
-			'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
-			'username' => 'root',
-		));
+        DB::configuration('test', array(
+            'dsn' => 'mysql:dbname=test-db;host=127.0.0.1',
+            'username' => 'root',
+        ));
 
-		$default = DB::instance();
-		$test = DB::instance('test');
+        $default = DB::instance();
+        $test = DB::instance('test');
 
-		$this->assertNotSame($default, $test);
+        $this->assertNotSame($default, $test);
 
-		$this->assertSame($default, DB::instance());
-		$this->assertSame($test, DB::instance('test'));
-	}
+        $this->assertSame($default, DB::instance());
+        $this->assertSame($test, DB::instance('test'));
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::execute
-	 */
-	public function testExecute()
-	{
-		$sql = 'SELECT * FROM users WHERE name = ?';
-		$parameters = array('User 1');
+    /**
+     * @covers CL\Atlas\DB::execute
+     */
+    public function testExecute()
+    {
+        $sql = 'SELECT * FROM users WHERE name = ?';
+        $parameters = array('User 1');
 
-		$expected = array(
-			array('id' => 1, 'name' => 'User 1'),
-		);
+        $expected = array(
+            array('id' => 1, 'name' => 'User 1'),
+        );
 
-		$this->assertEquals($expected, DB::instance()->execute($sql, $parameters)->fetchAll());
-	}
+        $this->assertEquals($expected, DB::instance()->execute($sql, $parameters)->fetchAll());
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::select
-	 */
-	public function testSelect()
-	{
-		$select = DB::instance()->select()->columns(array('test', 'test2'));
+    /**
+     * @covers CL\Atlas\DB::select
+     */
+    public function testSelect()
+    {
+        $select = DB::instance()->select()->columns(array('test', 'test2'));
 
-		$this->assertInstanceOf('CL\Atlas\Query\SelectQuery', $select);
+        $this->assertInstanceOf('CL\Atlas\Query\SelectQuery', $select);
 
-		$this->assertSame(DB::instance(), $select->db());
+        $this->assertSame(DB::instance(), $select->db());
 
-		$this->assertEquals('SELECT test, test2', $select->sql());
-	}
+        $this->assertEquals('SELECT test, test2', $select->sql());
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::update
-	 */
-	public function testUpdate()
-	{
-		$update = DB::instance()->update()->table(array('test', 'test2'));
+    /**
+     * @covers CL\Atlas\DB::update
+     */
+    public function testUpdate()
+    {
+        $update = DB::instance()->update()->table(array('test', 'test2'));
 
-		$this->assertInstanceOf('CL\Atlas\Query\UpdateQuery', $update);
+        $this->assertInstanceOf('CL\Atlas\Query\UpdateQuery', $update);
 
-		$this->assertSame(DB::instance(), $update->db());
+        $this->assertSame(DB::instance(), $update->db());
 
-		$this->assertEquals('UPDATE test, test2', $update->sql());
-	}
+        $this->assertEquals('UPDATE test, test2', $update->sql());
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::delete
-	 */
-	public function testDelete()
-	{
-		$delete = DB::instance()->delete()->from(array('test', 'test2'));
+    /**
+     * @covers CL\Atlas\DB::delete
+     */
+    public function testDelete()
+    {
+        $delete = DB::instance()->delete()->from(array('test', 'test2'));
 
-		$this->assertInstanceOf('CL\Atlas\Query\DeleteQuery', $delete);
+        $this->assertInstanceOf('CL\Atlas\Query\DeleteQuery', $delete);
 
-		$this->assertSame(DB::instance(), $delete->db());
+        $this->assertSame(DB::instance(), $delete->db());
 
-		$this->assertEquals('DELETE FROM test, test2', $delete->sql());
-	}
+        $this->assertEquals('DELETE FROM test, test2', $delete->sql());
+    }
 
-	/**
-	 * @covers CL\Atlas\DB::insert
-	 */
-	public function testInsert()
-	{
-		$query = DB::instance()->insert()->into('table1')->set(array('name' => 'test2'));
+    /**
+     * @covers CL\Atlas\DB::insert
+     */
+    public function testInsert()
+    {
+        $query = DB::instance()->insert()->into('table1')->set(array('name' => 'test2'));
 
-		$this->assertInstanceOf('CL\Atlas\Query\InsertQuery', $query);
+        $this->assertInstanceOf('CL\Atlas\Query\InsertQuery', $query);
 
-		$this->assertSame(DB::instance(), $query->db());
+        $this->assertSame(DB::instance(), $query->db());
 
-		$this->assertEquals('INSERT INTO table1 SET name = ?', $query->sql());
-		$this->assertEquals(array('test2'), $query->parameters());
-	}
+        $this->assertEquals('INSERT INTO table1 SET name = ?', $query->sql());
+        $this->assertEquals(array('test2'), $query->parameters());
+    }
 }

--- a/tests/src/ParametrisedStub.php
+++ b/tests/src/ParametrisedStub.php
@@ -4,5 +4,8 @@ use CL\Atlas\Parametrised;
 
 class ParametrisedStub implements Parametrised
 {
-    public function parameters() {}
+    public function parameters()
+    {
+
+    }
 }

--- a/tests/src/ParametrisedStub.php
+++ b/tests/src/ParametrisedStub.php
@@ -4,5 +4,5 @@ use CL\Atlas\Parametrised;
 
 class ParametrisedStub implements Parametrised
 {
-	public function parameters() {}
+    public function parameters() {}
 }

--- a/tests/src/Query/DeleteQueryTest.php
+++ b/tests/src/Query/DeleteQueryTest.php
@@ -13,142 +13,142 @@ use CL\Atlas\SQL\DirectionSQL;
  */
 class DeleteQueryTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::type
-	 */
-	public function testType()
-	{
-		$query = new DeleteQuery;
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::type
+     */
+    public function testType()
+    {
+        $query = new DeleteQuery;
 
-		$query->type('IGNORE');
+        $query->type('IGNORE');
 
-		$this->assertEquals('IGNORE', $query->children(Query::TYPE));
+        $this->assertEquals('IGNORE', $query->children(Query::TYPE));
 
-		$query->type('IGNORE QUICK');
+        $query->type('IGNORE QUICK');
 
-		$this->assertEquals('IGNORE QUICK', $query->children(Query::TYPE));
-	}
+        $this->assertEquals('IGNORE QUICK', $query->children(Query::TYPE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::table
-	 */
-	public function testTable()
-	{
-		$query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildren'));
-		$query
-			->expects($this->at(0))
-			->method('addChildren')
-			->with($this->equalTo(Query::TABLE), $this->equalTo(array('table1')));
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::table
+     */
+    public function testTable()
+    {
+        $query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildren'));
+        $query
+            ->expects($this->at(0))
+            ->method('addChildren')
+            ->with($this->equalTo(Query::TABLE), $this->equalTo(array('table1')));
 
-		$query
-			->expects($this->at(1))
-			->method('addChildren')
-			->with($this->equalTo(Query::TABLE), $this->equalTo(array('table1', 'table2')));
+        $query
+            ->expects($this->at(1))
+            ->method('addChildren')
+            ->with($this->equalTo(Query::TABLE), $this->equalTo(array('table1', 'table2')));
 
-		$query->table('table1');
-		$query->table(array('table1', 'table2'));
-	}
+        $query->table('table1');
+        $query->table(array('table1', 'table2'));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::from
-	 */
-	public function testFrom()
-	{
-		$query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::FROM),
-				$this->equalTo(array('table1', 'table2' => 'alias2')),
-				$this->equalTo('alias'),
-				'CL\Atlas\SQL\AliasedSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::from
+     */
+    public function testFrom()
+    {
+        $query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::FROM),
+                $this->equalTo(array('table1', 'table2' => 'alias2')),
+                $this->equalTo('alias'),
+                'CL\Atlas\SQL\AliasedSQL::factory'
+            );
 
-		$query->from(array('table1', 'table2' => 'alias2'), 'alias');
-	}
+        $query->from(array('table1', 'table2' => 'alias2'), 'alias');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::join
-	 */
-	public function testJoin()
-	{
-		$query = new DeleteQuery;
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::join
+     */
+    public function testJoin()
+    {
+        $query = new DeleteQuery;
 
-		$query
-			->join('table1', array('col' => 'col2'))
-			->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
+        $query
+            ->join('table1', array('col' => 'col2'))
+            ->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
 
-		$expected = array(
-			new JoinSQL('table1', array('col' => 'col2')),
-			new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
-		);
+        $expected = array(
+            new JoinSQL('table1', array('col' => 'col2')),
+            new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::JOIN));
-	}
+        $this->assertEquals($expected, $query->children(Query::JOIN));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::where
-	 */
-	public function testWhere()
-	{
-		$query = new DeleteQuery;
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::where
+     */
+    public function testWhere()
+    {
+        $query = new DeleteQuery;
 
-		$query
-			->where(array('test' => 20))
-			->where('column = ? OR column = ?', 10, 20);
+        $query
+            ->where(array('test' => 20))
+            ->where('column = ? OR column = ?', 10, 20);
 
-		$expected = array(
-			new ConditionSQL(array('test' => 20)),
-			new ConditionSQL('column = ? OR column = ?', array(10, 20)),
-		);
+        $expected = array(
+            new ConditionSQL(array('test' => 20)),
+            new ConditionSQL('column = ? OR column = ?', array(10, 20)),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::WHERE));
-	}
+        $this->assertEquals($expected, $query->children(Query::WHERE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::order
-	 */
-	public function testOrder()
-	{
-		$query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::ORDER_BY),
-				$this->equalTo(array('column1', 'column2' => 'alias2')),
-				$this->equalTo('direction'),
-				'CL\Atlas\SQL\DirectionSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::order
+     */
+    public function testOrder()
+    {
+        $query = $this->getMock('CL\Atlas\Query\DeleteQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::ORDER_BY),
+                $this->equalTo(array('column1', 'column2' => 'alias2')),
+                $this->equalTo('direction'),
+                'CL\Atlas\SQL\DirectionSQL::factory'
+            );
 
-		$query->order(array('column1', 'column2' => 'alias2'), 'direction');
-	}
+        $query->order(array('column1', 'column2' => 'alias2'), 'direction');
+    }
 
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::limit
-	 */
-	public function testLimit()
-	{
-		$query = new DeleteQuery;
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::limit
+     */
+    public function testLimit()
+    {
+        $query = new DeleteQuery;
 
-		$query->limit(20);
+        $query->limit(20);
 
-		$this->assertEquals(20, $query->children(Query::LIMIT));
-	}
+        $this->assertEquals(20, $query->children(Query::LIMIT));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\DeleteQuery::sql
-	 */
-	public function testSql()
-	{
-		$query = new DeleteQuery;
+    /**
+     * @covers CL\Atlas\Query\DeleteQuery::sql
+     */
+    public function testSql()
+    {
+        $query = new DeleteQuery;
 
-		$query
-			->from('table1')
-			->limit(10);
+        $query
+            ->from('table1')
+            ->limit(10);
 
-		$this->assertEquals('DELETE FROM table1 LIMIT 10', $query->sql());
-	}
+        $this->assertEquals('DELETE FROM table1 LIMIT 10', $query->sql());
+    }
 }

--- a/tests/src/Query/DeleteQueryTest.php
+++ b/tests/src/Query/DeleteQueryTest.php
@@ -11,7 +11,8 @@ use CL\Atlas\SQL\DirectionSQL;
 /**
  * @group sql.delete
  */
-class DeleteQueryTest extends AbstractTestCase {
+class DeleteQueryTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Query\DeleteQuery::type

--- a/tests/src/Query/InsertQueryTest.php
+++ b/tests/src/Query/InsertQueryTest.php
@@ -16,109 +16,109 @@ use CL\Atlas\SQL\SetSQL;
  */
 class InsertQueryTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::type
-	 */
-	public function testType()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::type
+     */
+    public function testType()
+    {
+        $query = new InsertQuery;
 
-		$query->type('IGNORE');
+        $query->type('IGNORE');
 
-		$this->assertEquals('IGNORE', $query->children(Query::TYPE));
-	}
+        $this->assertEquals('IGNORE', $query->children(Query::TYPE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::into
-	 */
-	public function testInto()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::into
+     */
+    public function testInto()
+    {
+        $query = new InsertQuery;
 
-		$query->into('posts');
+        $query->into('posts');
 
-		$this->assertEquals('posts', $query->children(Query::TABLE));
-	}
+        $this->assertEquals('posts', $query->children(Query::TABLE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::columns
-	 */
-	public function testColumns()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::columns
+     */
+    public function testColumns()
+    {
+        $query = new InsertQuery;
 
-		$query->columns('posts');
+        $query->columns('posts');
 
-		$this->assertEquals(array('posts'), $query->children(Query::COLUMNS));
+        $this->assertEquals(array('posts'), $query->children(Query::COLUMNS));
 
-		$query->columns(array('col1', 'col2'));
+        $query->columns(array('col1', 'col2'));
 
-		$this->assertEquals(array('posts', 'col1', 'col2'), $query->children(Query::COLUMNS));
-	}
+        $this->assertEquals(array('posts', 'col1', 'col2'), $query->children(Query::COLUMNS));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::values
-	 */
-	public function testValues()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::values
+     */
+    public function testValues()
+    {
+        $query = new InsertQuery;
 
-		$query
-			->values(array(10, 20))
-			->values(array(16, 26));
+        $query
+            ->values(array(10, 20))
+            ->values(array(16, 26));
 
-		$expected = array(
-			new ValuesSQL(array(10, 20)),
-			new ValuesSQL(array(16, 26)),
-		);
+        $expected = array(
+            new ValuesSQL(array(10, 20)),
+            new ValuesSQL(array(16, 26)),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::VALUES));
-	}
+        $this->assertEquals($expected, $query->children(Query::VALUES));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::set
-	 */
-	public function testSet()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::set
+     */
+    public function testSet()
+    {
+        $query = new InsertQuery;
 
-		$query
-			->set(array('test' => 20, 'value' => 10))
-			->set(array('name' => 'test'));
+        $query
+            ->set(array('test' => 20, 'value' => 10))
+            ->set(array('name' => 'test'));
 
-		$expected = array(
-			new SetSQL('test', 20),
-			new SetSQL('value', 10),
-			new SetSQL('name', 'test'),
-		);
+        $expected = array(
+            new SetSQL('test', 20),
+            new SetSQL('value', 10),
+            new SetSQL('name', 'test'),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::SET));
-	}
+        $this->assertEquals($expected, $query->children(Query::SET));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::select
-	 */
-	public function testSelect()
-	{
-		$select = new SelectQuery;
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::select
+     */
+    public function testSelect()
+    {
+        $select = new SelectQuery;
+        $query = new InsertQuery;
 
-		$query->select($select);
+        $query->select($select);
 
-		$this->assertSame($select, $query->children(Query::SELECT));
-	}
+        $this->assertSame($select, $query->children(Query::SELECT));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\InsertQuery::sql
-	 */
-	public function testSql()
-	{
-		$query = new InsertQuery;
+    /**
+     * @covers CL\Atlas\Query\InsertQuery::sql
+     */
+    public function testSql()
+    {
+        $query = new InsertQuery;
 
-		$query
-			->into('table1')
-			->set(array('name' => 10));
+        $query
+            ->into('table1')
+            ->set(array('name' => 10));
 
-		$this->assertEquals('INSERT INTO table1 SET name = ?', $query->sql());
-	}
+        $this->assertEquals('INSERT INTO table1 SET name = ?', $query->sql());
+    }
 }

--- a/tests/src/Query/InsertQueryTest.php
+++ b/tests/src/Query/InsertQueryTest.php
@@ -14,7 +14,8 @@ use CL\Atlas\SQL\SetSQL;
 /**
  * @group sql.insert
  */
-class InsertQueryTest extends AbstractTestCase {
+class InsertQueryTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Query\InsertQuery::type

--- a/tests/src/Query/QueryTest.php
+++ b/tests/src/Query/QueryTest.php
@@ -47,7 +47,7 @@ class QueryTest extends AbstractTestCase {
 
         $this->assertEquals('ignore', $query->children(Query::TYPE));
         $this->assertEquals(10, $query->children(Query::LIMIT));
-        $this->assertEquals(NULL, $query->children('non existant'));
+        $this->assertEquals(null, $query->children('non existant'));
     }
 
     /**
@@ -109,8 +109,8 @@ class QueryTest extends AbstractTestCase {
         return array(
             array(
                 'test',
-                NULL,
-                array(array('test', NULL, 'result')),
+                null,
+                array(array('test', null, 'result')),
                 array('result')
             ),
             array(
@@ -121,22 +121,22 @@ class QueryTest extends AbstractTestCase {
             ),
             array(
                 array('test'),
-                NULL,
-                array(array('test', NULL, 'result')),
+                null,
+                array(array('test', null, 'result')),
                 array('result')
             ),
             array(
                 array('test' => 'arg'),
-                NULL,
+                null,
                 array(array('test', 'arg', 'result')),
                 array('result')
             ),
             array(
                 array('test1' => 'arg1', 'test2', 'test3' => 'arg3'),
-                NULL,
+                null,
                 array(
                     array('test1', 'arg1', 'result1'),
-                    array('test2', NULL, 'result2'),
+                    array('test2', null, 'result2'),
                     array('test3', 'arg3', 'result3'),
                 ),
                 array('result1', 'result2', 'result3')),
@@ -178,7 +178,7 @@ class QueryTest extends AbstractTestCase {
     {
         $db = new DB(array());
 
-        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(NULL, $db));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(null, $db));
 
         $this->assertSame($db, $query->db());
 

--- a/tests/src/Query/QueryTest.php
+++ b/tests/src/Query/QueryTest.php
@@ -10,7 +10,8 @@ use CL\Atlas\Test\ParametrisedStub;
 /**
  * @group str
  */
-class QueryTest extends AbstractTestCase {
+class QueryTest extends AbstractTestCase
+{
 
     public function testConstants()
     {

--- a/tests/src/Query/QueryTest.php
+++ b/tests/src/Query/QueryTest.php
@@ -12,223 +12,223 @@ use CL\Atlas\Test\ParametrisedStub;
  */
 class QueryTest extends AbstractTestCase {
 
-	public function testConstants()
-	{
-		$constants = array(
-			Query::TYPE,
-			Query::TABLE,
-			Query::FROM,
-			Query::JOIN,
-			Query::COLUMNS,
-			Query::VALUES,
-			Query::SELECT,
-			Query::SET,
-			Query::WHERE,
-			Query::HAVING,
-			Query::GROUP_BY,
-			Query::ORDER_BY,
-			Query::LIMIT,
-			Query::OFFSET,
-		);
+    public function testConstants()
+    {
+        $constants = array(
+            Query::TYPE,
+            Query::TABLE,
+            Query::FROM,
+            Query::JOIN,
+            Query::COLUMNS,
+            Query::VALUES,
+            Query::SELECT,
+            Query::SET,
+            Query::WHERE,
+            Query::HAVING,
+            Query::GROUP_BY,
+            Query::ORDER_BY,
+            Query::LIMIT,
+            Query::OFFSET,
+        );
 
-		$this->assertEquals(count($constants), count(array_unique($constants)), 'Should not have repeating values');
-	}
+        $this->assertEquals(count($constants), count(array_unique($constants)), 'Should not have repeating values');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::children
-	 */
-	public function testChildren()
-	{
-		$children = array(Query::TYPE => 'ignore', Query::LIMIT => 10);
+    /**
+     * @covers CL\Atlas\Query\Query::children
+     */
+    public function testChildren()
+    {
+        $children = array(Query::TYPE => 'ignore', Query::LIMIT => 10);
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array($children));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array($children));
 
-		$this->assertEquals($children, $query->children());
+        $this->assertEquals($children, $query->children());
 
-		$this->assertEquals('ignore', $query->children(Query::TYPE));
-		$this->assertEquals(10, $query->children(Query::LIMIT));
-		$this->assertEquals(NULL, $query->children('non existant'));
-	}
+        $this->assertEquals('ignore', $query->children(Query::TYPE));
+        $this->assertEquals(10, $query->children(Query::LIMIT));
+        $this->assertEquals(NULL, $query->children('non existant'));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::parameters
-	 */
-	public function testParameters()
-	{
-		$object1 = $this->getMock('CL\Atlas\Test\ParametrisedStub', array('parameters'));
-		$object1
-			->expects($this->once())
-			->method('parameters')
-			->will($this->returnValue(array('test1', 'test2', array('test3', 'test4'))));
+    /**
+     * @covers CL\Atlas\Query\Query::parameters
+     */
+    public function testParameters()
+    {
+        $object1 = $this->getMock('CL\Atlas\Test\ParametrisedStub', array('parameters'));
+        $object1
+            ->expects($this->once())
+            ->method('parameters')
+            ->will($this->returnValue(array('test1', 'test2', array('test3', 'test4'))));
 
-		$object2 = $this->getMock('CL\Atlas\Test\ParametrisedStub', array('parameters'));
-		$object2
-			->expects($this->once())
-			->method('parameters')
-			->will($this->returnValue(array('test5')));
+        $object2 = $this->getMock('CL\Atlas\Test\ParametrisedStub', array('parameters'));
+        $object2
+            ->expects($this->once())
+            ->method('parameters')
+            ->will($this->returnValue(array('test5')));
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(array('test', array($object1), $object2)));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(array('test', array($object1), $object2)));
 
-		$this->assertEquals(array('test1', 'test2', 'test3', 'test4', 'test5'), $query->parameters());
+        $this->assertEquals(array('test1', 'test2', 'test3', 'test4', 'test5'), $query->parameters());
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
 
-		$this->assertEquals(array(), $query->parameters());
-	}
+        $this->assertEquals(array(), $query->parameters());
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::addChildren
-	 * @covers CL\Atlas\Query\Query::__construct
-	 */
-	public function testAddChildren()
-	{
-		$child1 = new stdClass;
-		$child2 = new stdClass;
-		$child3 = new stdClass;
+    /**
+     * @covers CL\Atlas\Query\Query::addChildren
+     * @covers CL\Atlas\Query\Query::__construct
+     */
+    public function testAddChildren()
+    {
+        $child1 = new stdClass;
+        $child2 = new stdClass;
+        $child3 = new stdClass;
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(array(Query::TABLE => array($child1))));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(array(Query::TABLE => array($child1))));
 
-		$query->addChildren(Query::TABLE, array($child2));
-		$query->addChildren(Query::COLUMNS, array($child3));
+        $query->addChildren(Query::TABLE, array($child2));
+        $query->addChildren(Query::COLUMNS, array($child3));
 
-		$expected_children = array(
-			Query::TABLE => array(
-				$child1,
-				$child2,
-			),
-			Query::COLUMNS => array(
-				$child3,
-			),
-		);
+        $expected_children = array(
+            Query::TABLE => array(
+                $child1,
+                $child2,
+            ),
+            Query::COLUMNS => array(
+                $child3,
+            ),
+        );
 
-		$this->assertEquals($expected_children, $query->children());
-	}
+        $this->assertEquals($expected_children, $query->children());
+    }
 
-	public function dataAddChildrenObjects()
-	{
-		return array(
-			array(
-				'test',
-				NULL,
-				array(array('test', NULL, 'result')),
-				array('result')
-			),
-			array(
-				'test',
-				'arg',
-				array(array('test', 'arg', 'result')),
-				array('result')
-			),
-			array(
-				array('test'),
-				NULL,
-				array(array('test', NULL, 'result')),
-				array('result')
-			),
-			array(
-				array('test' => 'arg'),
-				NULL,
-				array(array('test', 'arg', 'result')),
-				array('result')
-			),
-			array(
-				array('test1' => 'arg1', 'test2', 'test3' => 'arg3'),
-				NULL,
-				array(
-					array('test1', 'arg1', 'result1'),
-					array('test2', NULL, 'result2'),
-					array('test3', 'arg3', 'result3'),
-				),
-				array('result1', 'result2', 'result3')),
-		);
-	}
+    public function dataAddChildrenObjects()
+    {
+        return array(
+            array(
+                'test',
+                NULL,
+                array(array('test', NULL, 'result')),
+                array('result')
+            ),
+            array(
+                'test',
+                'arg',
+                array(array('test', 'arg', 'result')),
+                array('result')
+            ),
+            array(
+                array('test'),
+                NULL,
+                array(array('test', NULL, 'result')),
+                array('result')
+            ),
+            array(
+                array('test' => 'arg'),
+                NULL,
+                array(array('test', 'arg', 'result')),
+                array('result')
+            ),
+            array(
+                array('test1' => 'arg1', 'test2', 'test3' => 'arg3'),
+                NULL,
+                array(
+                    array('test1', 'arg1', 'result1'),
+                    array('test2', NULL, 'result2'),
+                    array('test3', 'arg3', 'result3'),
+                ),
+                array('result1', 'result2', 'result3')),
+        );
+    }
 
-	/**
-	 * @dataProvider dataAddChildrenObjects
-	 * @covers CL\Atlas\Query\Query::addChildrenObjects
-	 */
-	public function testAddChildrenObjects($array, $argument, $calls)
-	{
-		$class = $this->getMock('stdClass', array('testMethod'));
+    /**
+     * @dataProvider dataAddChildrenObjects
+     * @covers CL\Atlas\Query\Query::addChildrenObjects
+     */
+    public function testAddChildrenObjects($array, $argument, $calls)
+    {
+        $class = $this->getMock('stdClass', array('testMethod'));
 
-		$expected = array();
+        $expected = array();
 
-		foreach ($calls as $index => $call)
-		{
-			$class
-				->expects($this->at($index))
-				->method('testMethod')
-				->with($this->equalTo($call[0]), $this->equalTo($call[1]))
-				->will($this->returnValue($call[2]));
+        foreach ($calls as $index => $call)
+        {
+            $class
+                ->expects($this->at($index))
+                ->method('testMethod')
+                ->with($this->equalTo($call[0]), $this->equalTo($call[1]))
+                ->will($this->returnValue($call[2]));
 
-			$expected []= $call[2];
-		}
+            $expected []= $call[2];
+        }
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
 
 
-		$query->addChildrenObjects(Query::TABLE, $array, $argument, array($class, 'testMethod'));
+        $query->addChildrenObjects(Query::TABLE, $array, $argument, array($class, 'testMethod'));
 
-		$this->assertEquals($query->children(Query::TABLE), $expected);
-	}
+        $this->assertEquals($query->children(Query::TABLE), $expected);
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::db
-	 */
-	public function testDb()
-	{
-		$db = new DB(array());
+    /**
+     * @covers CL\Atlas\Query\Query::db
+     */
+    public function testDb()
+    {
+        $db = new DB(array());
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(NULL, $db));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'), array(NULL, $db));
 
-		$this->assertSame($db, $query->db());
+        $this->assertSame($db, $query->db());
 
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql'));
 
-		$this->assertSame(DB::instance(), $query->db());
-	}
+        $this->assertSame(DB::instance(), $query->db());
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::execute
-	 */
-	public function testExecute()
-	{
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql', 'parameters'));
+    /**
+     * @covers CL\Atlas\Query\Query::execute
+     */
+    public function testExecute()
+    {
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql', 'parameters'));
 
-		$query
-			->expects($this->once())
-			->method('sql')
-			->will($this->returnValue('SELECT * FROM users WHERE name = ?'));
+        $query
+            ->expects($this->once())
+            ->method('sql')
+            ->will($this->returnValue('SELECT * FROM users WHERE name = ?'));
 
-		$query
-			->expects($this->once())
-			->method('parameters')
-			->will($this->returnValue(array('User 1')));
+        $query
+            ->expects($this->once())
+            ->method('parameters')
+            ->will($this->returnValue(array('User 1')));
 
-		$expected = array(
-			array('id' => 1, 'name' => 'User 1'),
-		);
+        $expected = array(
+            array('id' => 1, 'name' => 'User 1'),
+        );
 
-		$this->assertEquals($expected, $query->execute()->fetchAll());
-	}
+        $this->assertEquals($expected, $query->execute()->fetchAll());
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\Query::humanize
-	 */
-	public function testHumanize()
-	{
-		$query = $this->getMock('CL\Atlas\Query\Query', array('sql', 'parameters'));
+    /**
+     * @covers CL\Atlas\Query\Query::humanize
+     */
+    public function testHumanize()
+    {
+        $query = $this->getMock('CL\Atlas\Query\Query', array('sql', 'parameters'));
 
-		$query
-			->expects($this->once())
-			->method('sql')
-			->will($this->returnValue('SELECT * FROM users WHERE name = ?'));
+        $query
+            ->expects($this->once())
+            ->method('sql')
+            ->will($this->returnValue('SELECT * FROM users WHERE name = ?'));
 
-		$query
-			->expects($this->once())
-			->method('parameters')
-			->will($this->returnValue(array('User 1')));
+        $query
+            ->expects($this->once())
+            ->method('parameters')
+            ->will($this->returnValue(array('User 1')));
 
-		$this->assertEquals('SELECT * FROM users WHERE name = "User 1"', $query->humanize());
-	}
+        $this->assertEquals('SELECT * FROM users WHERE name = "User 1"', $query->humanize());
+    }
 }

--- a/tests/src/Query/QueryTest.php
+++ b/tests/src/Query/QueryTest.php
@@ -153,8 +153,7 @@ class QueryTest extends AbstractTestCase {
 
         $expected = array();
 
-        foreach ($calls as $index => $call)
-        {
+        foreach ($calls as $index => $call) {
             $class
                 ->expects($this->at($index))
                 ->method('testMethod')

--- a/tests/src/Query/SelectQueryTest.php
+++ b/tests/src/Query/SelectQueryTest.php
@@ -11,186 +11,186 @@ use CL\Atlas\SQL\JoinSQL;
  */
 class SelectQueryTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::type
-	 */
-	public function testType()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::type
+     */
+    public function testType()
+    {
+        $query = new SelectQuery;
 
-		$query->type('IGNORE');
+        $query->type('IGNORE');
 
-		$this->assertEquals('IGNORE', $query->children(Query::TYPE));
-	}
+        $this->assertEquals('IGNORE', $query->children(Query::TYPE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::columns
-	 */
-	public function testColumns()
-	{
-		$query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::COLUMNS),
-				$this->equalTo(array('column1', 'column2' => 'alias2')),
-				$this->equalTo('alias'),
-				'CL\Atlas\SQL\AliasedSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::columns
+     */
+    public function testColumns()
+    {
+        $query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::COLUMNS),
+                $this->equalTo(array('column1', 'column2' => 'alias2')),
+                $this->equalTo('alias'),
+                'CL\Atlas\SQL\AliasedSQL::factory'
+            );
 
-		$query->columns(array('column1', 'column2' => 'alias2'), 'alias');
-	}
+        $query->columns(array('column1', 'column2' => 'alias2'), 'alias');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::from
-	 */
-	public function testFrom()
-	{
-		$query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::FROM),
-				$this->equalTo(array('table1', 'table2' => 'alias2')),
-				$this->equalTo('alias'),
-				'CL\Atlas\SQL\AliasedSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::from
+     */
+    public function testFrom()
+    {
+        $query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::FROM),
+                $this->equalTo(array('table1', 'table2' => 'alias2')),
+                $this->equalTo('alias'),
+                'CL\Atlas\SQL\AliasedSQL::factory'
+            );
 
-		$query->from(array('table1', 'table2' => 'alias2'), 'alias');
-	}
+        $query->from(array('table1', 'table2' => 'alias2'), 'alias');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::join
-	 */
-	public function testJoin()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::join
+     */
+    public function testJoin()
+    {
+        $query = new SelectQuery;
 
-		$query
-			->join('table1', array('col' => 'col2'))
-			->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
+        $query
+            ->join('table1', array('col' => 'col2'))
+            ->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
 
-		$expected = array(
-			new JoinSQL('table1', array('col' => 'col2')),
-			new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
-		);
+        $expected = array(
+            new JoinSQL('table1', array('col' => 'col2')),
+            new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::JOIN));
-	}
+        $this->assertEquals($expected, $query->children(Query::JOIN));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::where
-	 */
-	public function testWhere()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::where
+     */
+    public function testWhere()
+    {
+        $query = new SelectQuery;
 
-		$query
-			->where(array('test' => 20))
-			->where('column = ? OR column = ?', 10, 20);
+        $query
+            ->where(array('test' => 20))
+            ->where('column = ? OR column = ?', 10, 20);
 
-		$expected = array(
-			new ConditionSQL(array('test' => 20)),
-			new ConditionSQL('column = ? OR column = ?', array(10, 20)),
-		);
+        $expected = array(
+            new ConditionSQL(array('test' => 20)),
+            new ConditionSQL('column = ? OR column = ?', array(10, 20)),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::WHERE));
-	}
+        $this->assertEquals($expected, $query->children(Query::WHERE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::group
-	 */
-	public function testGroup()
-	{
-		$query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::GROUP_BY),
-				$this->equalTo(array('column1', 'column2' => 'alias2')),
-				$this->equalTo('direction'),
-				'CL\Atlas\SQL\DirectionSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::group
+     */
+    public function testGroup()
+    {
+        $query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::GROUP_BY),
+                $this->equalTo(array('column1', 'column2' => 'alias2')),
+                $this->equalTo('direction'),
+                'CL\Atlas\SQL\DirectionSQL::factory'
+            );
 
-		$query->group(array('column1', 'column2' => 'alias2'), 'direction');
-	}
+        $query->group(array('column1', 'column2' => 'alias2'), 'direction');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::having
-	 */
-	public function testHaving()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::having
+     */
+    public function testHaving()
+    {
+        $query = new SelectQuery;
 
-		$query
-			->having(array('test' => 20))
-			->having('column = ? OR column = ?', 10, 20);
+        $query
+            ->having(array('test' => 20))
+            ->having('column = ? OR column = ?', 10, 20);
 
-		$expected = array(
-			new ConditionSQL(array('test' => 20)),
-			new ConditionSQL('column = ? OR column = ?', array(10, 20)),
-		);
+        $expected = array(
+            new ConditionSQL(array('test' => 20)),
+            new ConditionSQL('column = ? OR column = ?', array(10, 20)),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::HAVING));
-	}
+        $this->assertEquals($expected, $query->children(Query::HAVING));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::order
-	 */
-	public function testOrder()
-	{
-		$query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::ORDER_BY),
-				$this->equalTo(array('column1', 'column2' => 'alias2')),
-				$this->equalTo('direction'),
-				'CL\Atlas\SQL\DirectionSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::order
+     */
+    public function testOrder()
+    {
+        $query = $this->getMock('CL\Atlas\Query\SelectQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::ORDER_BY),
+                $this->equalTo(array('column1', 'column2' => 'alias2')),
+                $this->equalTo('direction'),
+                'CL\Atlas\SQL\DirectionSQL::factory'
+            );
 
-		$query->order(array('column1', 'column2' => 'alias2'), 'direction');
-	}
+        $query->order(array('column1', 'column2' => 'alias2'), 'direction');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::limit
-	 */
-	public function testLimit()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::limit
+     */
+    public function testLimit()
+    {
+        $query = new SelectQuery;
 
-		$query->limit(20);
+        $query->limit(20);
 
-		$this->assertEquals(20, $query->children(Query::LIMIT));
-	}
+        $this->assertEquals(20, $query->children(Query::LIMIT));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::offset
-	 */
-	public function testOffset()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::offset
+     */
+    public function testOffset()
+    {
+        $query = new SelectQuery;
 
-		$query->offset(20);
+        $query->offset(20);
 
-		$this->assertEquals(20, $query->children(Query::OFFSET));
-	}
+        $this->assertEquals(20, $query->children(Query::OFFSET));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\SelectQuery::sql
-	 */
-	public function testSql()
-	{
-		$query = new SelectQuery;
+    /**
+     * @covers CL\Atlas\Query\SelectQuery::sql
+     */
+    public function testSql()
+    {
+        $query = new SelectQuery;
 
-		$query
-			->from('table1')
-			->where(array('name' => 10));
+        $query
+            ->from('table1')
+            ->where(array('name' => 10));
 
-		$this->assertEquals('SELECT * FROM table1 WHERE (name = ?)', $query->sql());
-	}
+        $this->assertEquals('SELECT * FROM table1 WHERE (name = ?)', $query->sql());
+    }
 }

--- a/tests/src/Query/SelectQueryTest.php
+++ b/tests/src/Query/SelectQueryTest.php
@@ -9,7 +9,8 @@ use CL\Atlas\SQL\JoinSQL;
 /**
  * @group sql.select
  */
-class SelectQueryTest extends AbstractTestCase {
+class SelectQueryTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Query\SelectQuery::type

--- a/tests/src/Query/UpdateQueryTest.php
+++ b/tests/src/Query/UpdateQueryTest.php
@@ -12,7 +12,8 @@ use CL\Atlas\SQL\SetSQL;
 /**
  * @group sql.update
  */
-class UpdateQueryTest extends AbstractTestCase {
+class UpdateQueryTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\Query\UpdateQuery::type

--- a/tests/src/Query/UpdateQueryTest.php
+++ b/tests/src/Query/UpdateQueryTest.php
@@ -14,138 +14,138 @@ use CL\Atlas\SQL\SetSQL;
  */
 class UpdateQueryTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::type
-	 */
-	public function testType()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::type
+     */
+    public function testType()
+    {
+        $query = new UpdateQuery;
 
-		$query->type('IGNORE');
+        $query->type('IGNORE');
 
-		$this->assertEquals('IGNORE', $query->children(Query::TYPE));
-	}
+        $this->assertEquals('IGNORE', $query->children(Query::TYPE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::table
-	 */
-	public function testTable()
-	{
-		$query = $this->getMock('CL\Atlas\Query\UpdateQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::TABLE),
-				$this->equalTo(array('table1', 'table2' => 'alias2')),
-				$this->equalTo('alias'),
-				'CL\Atlas\SQL\AliasedSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::table
+     */
+    public function testTable()
+    {
+        $query = $this->getMock('CL\Atlas\Query\UpdateQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::TABLE),
+                $this->equalTo(array('table1', 'table2' => 'alias2')),
+                $this->equalTo('alias'),
+                'CL\Atlas\SQL\AliasedSQL::factory'
+            );
 
-		$query->table(array('table1', 'table2' => 'alias2'), 'alias');
-	}
+        $query->table(array('table1', 'table2' => 'alias2'), 'alias');
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::join
-	 */
-	public function testJoin()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::join
+     */
+    public function testJoin()
+    {
+        $query = new UpdateQuery;
 
-		$query
-			->join('table1', array('col' => 'col2'))
-			->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
+        $query
+            ->join('table1', array('col' => 'col2'))
+            ->join(array('table2', 'alias2'), 'USING (col1)', 'LEFT');
 
-		$expected = array(
-			new JoinSQL('table1', array('col' => 'col2')),
-			new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
-		);
+        $expected = array(
+            new JoinSQL('table1', array('col' => 'col2')),
+            new JoinSQL(array('table2', 'alias2'), 'USING (col1)', 'LEFT'),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::JOIN));
-	}
+        $this->assertEquals($expected, $query->children(Query::JOIN));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::set
-	 */
-	public function testSet()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::set
+     */
+    public function testSet()
+    {
+        $query = new UpdateQuery;
 
-		$query
-			->set(array('test' => 20, 'value' => 10))
-			->set(array('name' => 'test'));
+        $query
+            ->set(array('test' => 20, 'value' => 10))
+            ->set(array('name' => 'test'));
 
-		$expected = array(
-			new SetSQL('test', 20),
-			new SetSQL('value', 10),
-			new SetSQL('name', 'test'),
-		);
+        $expected = array(
+            new SetSQL('test', 20),
+            new SetSQL('value', 10),
+            new SetSQL('name', 'test'),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::SET));
-	}
+        $this->assertEquals($expected, $query->children(Query::SET));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::where
-	 */
-	public function testWhere()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::where
+     */
+    public function testWhere()
+    {
+        $query = new UpdateQuery;
 
-		$query
-			->where(array('test' => 20))
-			->where('column = ? OR column = ?', 10, 20);
+        $query
+            ->where(array('test' => 20))
+            ->where('column = ? OR column = ?', 10, 20);
 
-		$expected = array(
-			new ConditionSQL(array('test' => 20)),
-			new ConditionSQL('column = ? OR column = ?', array(10, 20)),
-		);
+        $expected = array(
+            new ConditionSQL(array('test' => 20)),
+            new ConditionSQL('column = ? OR column = ?', array(10, 20)),
+        );
 
-		$this->assertEquals($expected, $query->children(Query::WHERE));
-	}
+        $this->assertEquals($expected, $query->children(Query::WHERE));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::order
-	 */
-	public function testOrder()
-	{
-		$query = $this->getMock('CL\Atlas\Query\UpdateQuery', array('addChildrenObjects'));
-		$query
-			->expects($this->once())
-			->method('addChildrenObjects')
-			->with(
-				$this->equalTo(Query::ORDER_BY),
-				$this->equalTo(array('column1', 'column2' => 'alias2')),
-				$this->equalTo('direction'),
-				'CL\Atlas\SQL\DirectionSQL::factory'
-			);
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::order
+     */
+    public function testOrder()
+    {
+        $query = $this->getMock('CL\Atlas\Query\UpdateQuery', array('addChildrenObjects'));
+        $query
+            ->expects($this->once())
+            ->method('addChildrenObjects')
+            ->with(
+                $this->equalTo(Query::ORDER_BY),
+                $this->equalTo(array('column1', 'column2' => 'alias2')),
+                $this->equalTo('direction'),
+                'CL\Atlas\SQL\DirectionSQL::factory'
+            );
 
-		$query->order(array('column1', 'column2' => 'alias2'), 'direction');
-	}
+        $query->order(array('column1', 'column2' => 'alias2'), 'direction');
+    }
 
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::limit
-	 */
-	public function testLimit()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::limit
+     */
+    public function testLimit()
+    {
+        $query = new UpdateQuery;
 
-		$query->limit(20);
+        $query->limit(20);
 
-		$this->assertEquals(20, $query->children(Query::LIMIT));
-	}
+        $this->assertEquals(20, $query->children(Query::LIMIT));
+    }
 
-	/**
-	 * @covers CL\Atlas\Query\UpdateQuery::sql
-	 */
-	public function testSql()
-	{
-		$query = new UpdateQuery;
+    /**
+     * @covers CL\Atlas\Query\UpdateQuery::sql
+     */
+    public function testSql()
+    {
+        $query = new UpdateQuery;
 
-		$query
-			->table('table1')
-			->set(array('name' => 10));
+        $query
+            ->table('table1')
+            ->set(array('name' => 10));
 
-		$this->assertEquals('UPDATE table1 SET name = ?', $query->sql());
-	}
+        $this->assertEquals('UPDATE table1 SET name = ?', $query->sql());
+    }
 }

--- a/tests/src/SQL/AliasedSQLTest.php
+++ b/tests/src/SQL/AliasedSQLTest.php
@@ -9,39 +9,39 @@ use CL\Atlas\SQL\AliasedSQL;
  */
 class AliasedSQLTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\SQL\AliasedSQL::factory
-	 */
-	public function testFactory()
-	{
-		$expected = new AliasedSQL('test', 'alias');
+    /**
+     * @covers CL\Atlas\SQL\AliasedSQL::factory
+     */
+    public function testFactory()
+    {
+        $expected = new AliasedSQL('test', 'alias');
 
-		$this->assertEquals($expected, AliasedSQL::factory('test', 'alias'));
-	}
+        $this->assertEquals($expected, AliasedSQL::factory('test', 'alias'));
+    }
 
-	/**
-	 * @covers CL\Atlas\SQL\AliasedSQL::__construct
-	 * @covers CL\Atlas\SQL\AliasedSQL::parameters
-	 * @covers CL\Atlas\SQL\AliasedSQL::alias
-	 */
-	public function testConstruct()
-	{
-		$aliased = new AliasedSQL('SQL', 'ALIAS');
+    /**
+     * @covers CL\Atlas\SQL\AliasedSQL::__construct
+     * @covers CL\Atlas\SQL\AliasedSQL::parameters
+     * @covers CL\Atlas\SQL\AliasedSQL::alias
+     */
+    public function testConstruct()
+    {
+        $aliased = new AliasedSQL('SQL', 'ALIAS');
 
-		$this->assertEquals('SQL', $aliased->content());
-		$this->assertEquals('ALIAS', $aliased->alias());
-		$this->assertNull($aliased->parameters());
+        $this->assertEquals('SQL', $aliased->content());
+        $this->assertEquals('ALIAS', $aliased->alias());
+        $this->assertNull($aliased->parameters());
 
-		$query = $this->getMock('CL\Atlas\Query\Query');
-		$query
-			->expects($this->once())
-			->method('parameters')
-			->will($this->returnValue(array('val')));
+        $query = $this->getMock('CL\Atlas\Query\Query');
+        $query
+            ->expects($this->once())
+            ->method('parameters')
+            ->will($this->returnValue(array('val')));
 
-		$aliased_query = new AliasedSQL($query, 'query_alias');
+        $aliased_query = new AliasedSQL($query, 'query_alias');
 
-		$this->assertSame($query, $aliased_query->content());
-		$this->assertEquals('query_alias', $aliased_query->alias());
-		$this->assertEquals(array('val'), $aliased_query->parameters());
-	}
+        $this->assertSame($query, $aliased_query->content());
+        $this->assertEquals('query_alias', $aliased_query->alias());
+        $this->assertEquals(array('val'), $aliased_query->parameters());
+    }
 }

--- a/tests/src/SQL/AliasedSQLTest.php
+++ b/tests/src/SQL/AliasedSQLTest.php
@@ -7,7 +7,8 @@ use CL\Atlas\SQL\AliasedSQL;
 /**
  * @group sql.aliased
  */
-class AliasedSQLTest extends AbstractTestCase {
+class AliasedSQLTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\SQL\AliasedSQL::factory

--- a/tests/src/SQL/ConditionSQLTest.php
+++ b/tests/src/SQL/ConditionSQLTest.php
@@ -16,7 +16,7 @@ class ConditionSQLTest extends AbstractTestCase {
             array('name = ? AND port = ?', array('name', 'val2'), 'name = ? AND port = ?', array('name', 'val2')),
             array(array('name' => 10), array(), 'name = ?', array(10)),
             array(array('name' => 10, 'id' => array(10, 20)), array(), 'name = ? AND id IN ?', array(10, array(10, 20))),
-            array(array('name' => NULL), array(), 'name IS ?', array(NULL)),
+            array(array('name' => null), array(), 'name IS ?', array(null)),
         );
     }
 

--- a/tests/src/SQL/ConditionSQLTest.php
+++ b/tests/src/SQL/ConditionSQLTest.php
@@ -9,25 +9,25 @@ use CL\Atlas\SQL\ConditionSQL;
  */
 class ConditionSQLTest extends AbstractTestCase {
 
-	public function dataConstruct()
-	{
-		return array(
-			array('name = ?', array('name'), 'name = ?', array('name')),
-			array('name = ? AND port = ?', array('name', 'val2'), 'name = ? AND port = ?', array('name', 'val2')),
-			array(array('name' => 10), array(), 'name = ?', array(10)),
-			array(array('name' => 10, 'id' => array(10, 20)), array(), 'name = ? AND id IN ?', array(10, array(10, 20))),
-			array(array('name' => NULL), array(), 'name IS ?', array(NULL)),
-		);
-	}
+    public function dataConstruct()
+    {
+        return array(
+            array('name = ?', array('name'), 'name = ?', array('name')),
+            array('name = ? AND port = ?', array('name', 'val2'), 'name = ? AND port = ?', array('name', 'val2')),
+            array(array('name' => 10), array(), 'name = ?', array(10)),
+            array(array('name' => 10, 'id' => array(10, 20)), array(), 'name = ? AND id IN ?', array(10, array(10, 20))),
+            array(array('name' => NULL), array(), 'name IS ?', array(NULL)),
+        );
+    }
 
-	/**
-	 * @dataProvider dataConstruct
-	 * @covers CL\Atlas\SQL\ConditionSQL::__construct
-	 */
-	public function testConstruct($argument, $params, $expected_condition, $expected_params)
-	{
-		$sql_condition = new ConditionSQL($argument, $params);
-		$this->assertEquals($expected_condition, $sql_condition->content());
-		$this->assertEquals($expected_params, $sql_condition->parameters());
-	}
+    /**
+     * @dataProvider dataConstruct
+     * @covers CL\Atlas\SQL\ConditionSQL::__construct
+     */
+    public function testConstruct($argument, $params, $expected_condition, $expected_params)
+    {
+        $sql_condition = new ConditionSQL($argument, $params);
+        $this->assertEquals($expected_condition, $sql_condition->content());
+        $this->assertEquals($expected_params, $sql_condition->parameters());
+    }
 }

--- a/tests/src/SQL/ConditionSQLTest.php
+++ b/tests/src/SQL/ConditionSQLTest.php
@@ -7,7 +7,8 @@ use CL\Atlas\SQL\ConditionSQL;
 /**
  * @group sql.condition
  */
-class ConditionSQLTest extends AbstractTestCase {
+class ConditionSQLTest extends AbstractTestCase
+{
 
     public function dataConstruct()
     {

--- a/tests/src/SQL/ConditionSQLTest.php
+++ b/tests/src/SQL/ConditionSQLTest.php
@@ -13,11 +13,36 @@ class ConditionSQLTest extends AbstractTestCase
     public function dataConstruct()
     {
         return array(
-            array('name = ?', array('name'), 'name = ?', array('name')),
-            array('name = ? AND port = ?', array('name', 'val2'), 'name = ? AND port = ?', array('name', 'val2')),
-            array(array('name' => 10), array(), 'name = ?', array(10)),
-            array(array('name' => 10, 'id' => array(10, 20)), array(), 'name = ? AND id IN ?', array(10, array(10, 20))),
-            array(array('name' => null), array(), 'name IS ?', array(null)),
+            array(
+                'name = ?',
+                array('name'),
+                'name = ?',
+                array('name')
+            ),
+            array(
+                'name = ? AND port = ?',
+                array('name', 'val2'),
+                'name = ? AND port = ?',
+                array('name', 'val2')
+            ),
+            array(
+                array('name' => 10),
+                array(),
+                'name = ?',
+                array(10)
+            ),
+            array(
+                array('name' => 10, 'id' => array(10, 20)),
+                array(),
+                'name = ? AND id IN ?',
+                array(10, array(10, 20))
+            ),
+            array(
+                array('name' => null),
+                array(),
+                'name IS ?',
+                array(null)
+            ),
         );
     }
 

--- a/tests/src/SQL/DirectionSQLTest.php
+++ b/tests/src/SQL/DirectionSQLTest.php
@@ -8,26 +8,26 @@ use CL\Atlas\SQL\DirectionSQL;
  */
 class DirectionSQLTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\SQL\DirectionSQL::factory
-	 */
-	public function testFactory()
-	{
-		$direction = DirectionSQL::factory('name', 'DESC');
-		$expected = new DirectionSQL('name', 'DESC');
+    /**
+     * @covers CL\Atlas\SQL\DirectionSQL::factory
+     */
+    public function testFactory()
+    {
+        $direction = DirectionSQL::factory('name', 'DESC');
+        $expected = new DirectionSQL('name', 'DESC');
 
-		$this->assertEquals($expected, $direction);
-	}
+        $this->assertEquals($expected, $direction);
+    }
 
-	/**
-	 * @covers CL\Atlas\SQL\DirectionSQL::__construct
-	 * @covers CL\Atlas\SQL\DirectionSQL::direction
-	 */
-	public function testConstruct()
-	{
-		$direction = new DirectionSQL('name', 'DESC');
+    /**
+     * @covers CL\Atlas\SQL\DirectionSQL::__construct
+     * @covers CL\Atlas\SQL\DirectionSQL::direction
+     */
+    public function testConstruct()
+    {
+        $direction = new DirectionSQL('name', 'DESC');
 
-		$this->assertEquals('name', $direction->content());
-		$this->assertEquals('DESC', $direction->direction());
-	}
+        $this->assertEquals('name', $direction->content());
+        $this->assertEquals('DESC', $direction->direction());
+    }
 }

--- a/tests/src/SQL/DirectionSQLTest.php
+++ b/tests/src/SQL/DirectionSQLTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\SQL\DirectionSQL;
 /**
  * @group sql.direction
  */
-class DirectionSQLTest extends AbstractTestCase {
+class DirectionSQLTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\SQL\DirectionSQL::factory

--- a/tests/src/SQL/JoinSQLTest.php
+++ b/tests/src/SQL/JoinSQLTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\AliasedSQL;
 /**
  * @group sql.join
  */
-class JoinSQLTest extends AbstractTestCase {
+class JoinSQLTest extends AbstractTestCase
+{
 
     public function dataConstruct()
     {

--- a/tests/src/SQL/JoinSQLTest.php
+++ b/tests/src/SQL/JoinSQLTest.php
@@ -14,9 +14,30 @@ class JoinSQLTest extends AbstractTestCase
     public function dataConstruct()
     {
         return array(
-            array('table', array('col' => 'col2'), 'LEFT', 'table', 'ON col = col2', 'LEFT'),
-            array(array('table' => 'alias1'), 'USING (col1)', null, new AliasedSQL('table', 'alias1'), 'USING (col1)', null),
-            array(new SQL('CUSTOM SQL'), array('col' => 'col2'), null, new SQL('CUSTOM SQL'), 'ON col = col2', null),
+            array(
+                'table',
+                array('col' => 'col2'),
+                'LEFT',
+                'table',
+                'ON col = col2',
+                'LEFT'
+            ),
+            array(
+                array('table' => 'alias1'),
+                'USING (col1)',
+                null,
+                new AliasedSQL('table', 'alias1'),
+                'USING (col1)',
+                null
+            ),
+            array(
+                new SQL('CUSTOM SQL'),
+                array('col' => 'col2'),
+                null,
+                new SQL('CUSTOM SQL'),
+                'ON col = col2',
+                null
+            ),
         );
     }
 

--- a/tests/src/SQL/JoinSQLTest.php
+++ b/tests/src/SQL/JoinSQLTest.php
@@ -10,44 +10,44 @@ use CL\Atlas\SQL\AliasedSQL;
  */
 class JoinSQLTest extends AbstractTestCase {
 
-	public function dataConstruct()
-	{
-		return array(
-			array('table', array('col' => 'col2'), 'LEFT', 'table', 'ON col = col2', 'LEFT'),
-			array(array('table' => 'alias1'), 'USING (col1)', NULL, new AliasedSQL('table', 'alias1'), 'USING (col1)', NULL),
-			array(new SQL('CUSTOM SQL'), array('col' => 'col2'), NULL, new SQL('CUSTOM SQL'), 'ON col = col2', NULL),
-		);
-	}
+    public function dataConstruct()
+    {
+        return array(
+            array('table', array('col' => 'col2'), 'LEFT', 'table', 'ON col = col2', 'LEFT'),
+            array(array('table' => 'alias1'), 'USING (col1)', NULL, new AliasedSQL('table', 'alias1'), 'USING (col1)', NULL),
+            array(new SQL('CUSTOM SQL'), array('col' => 'col2'), NULL, new SQL('CUSTOM SQL'), 'ON col = col2', NULL),
+        );
+    }
 
-	/**
-	 * @dataProvider dataConstruct
-	 * @covers CL\Atlas\SQL\JoinSQL::__construct
-	 * @covers CL\Atlas\SQL\JoinSQL::table
-	 * @covers CL\Atlas\SQL\JoinSQL::condition
-	 * @covers CL\Atlas\SQL\JoinSQL::type
-	 */
-	public function testConstruct($table, $condition, $type, $expected_table, $expected_condition, $expected_type)
-	{
-		$join = new JoinSQL($table, $condition, $type);
+    /**
+     * @dataProvider dataConstruct
+     * @covers CL\Atlas\SQL\JoinSQL::__construct
+     * @covers CL\Atlas\SQL\JoinSQL::table
+     * @covers CL\Atlas\SQL\JoinSQL::condition
+     * @covers CL\Atlas\SQL\JoinSQL::type
+     */
+    public function testConstruct($table, $condition, $type, $expected_table, $expected_condition, $expected_type)
+    {
+        $join = new JoinSQL($table, $condition, $type);
 
-		$this->assertEquals($expected_table, $join->table());
-		$this->assertEquals($expected_condition, $join->condition());
-		$this->assertEquals($expected_type, $join->type());
-	}
+        $this->assertEquals($expected_table, $join->table());
+        $this->assertEquals($expected_condition, $join->condition());
+        $this->assertEquals($expected_type, $join->type());
+    }
 
-	/**
-	 * @covers CL\Atlas\SQL\JoinSQL::parameters
-	 */
-	public function testFactory()
-	{
-		$condition = new SQL('ON col = ?', array('param'));
+    /**
+     * @covers CL\Atlas\SQL\JoinSQL::parameters
+     */
+    public function testFactory()
+    {
+        $condition = new SQL('ON col = ?', array('param'));
 
-		$join = new JoinSQL('table', $condition);
+        $join = new JoinSQL('table', $condition);
 
-		$this->assertEquals(array('param'), $join->parameters());
+        $this->assertEquals(array('param'), $join->parameters());
 
-		$join = new JoinSQL('table', array('col1' => 'col2'));
+        $join = new JoinSQL('table', array('col1' => 'col2'));
 
-		$this->assertNull($join->parameters());
-	}
+        $this->assertNull($join->parameters());
+    }
 }

--- a/tests/src/SQL/JoinSQLTest.php
+++ b/tests/src/SQL/JoinSQLTest.php
@@ -14,8 +14,8 @@ class JoinSQLTest extends AbstractTestCase {
     {
         return array(
             array('table', array('col' => 'col2'), 'LEFT', 'table', 'ON col = col2', 'LEFT'),
-            array(array('table' => 'alias1'), 'USING (col1)', NULL, new AliasedSQL('table', 'alias1'), 'USING (col1)', NULL),
-            array(new SQL('CUSTOM SQL'), array('col' => 'col2'), NULL, new SQL('CUSTOM SQL'), 'ON col = col2', NULL),
+            array(array('table' => 'alias1'), 'USING (col1)', null, new AliasedSQL('table', 'alias1'), 'USING (col1)', null),
+            array(new SQL('CUSTOM SQL'), array('col' => 'col2'), null, new SQL('CUSTOM SQL'), 'ON col = col2', null),
         );
     }
 

--- a/tests/src/SQL/SQLTest.php
+++ b/tests/src/SQL/SQLTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\SQL\SQL;
 /**
  * @group sql
  */
-class SQLTest extends AbstractTestCase {
+class SQLTest extends AbstractTestCase
+{
 
     /**
      * @covers CL\Atlas\SQL\SQL::__construct

--- a/tests/src/SQL/SQLTest.php
+++ b/tests/src/SQL/SQLTest.php
@@ -8,20 +8,20 @@ use CL\Atlas\SQL\SQL;
  */
 class SQLTest extends AbstractTestCase {
 
-	/**
-	 * @covers CL\Atlas\SQL\SQL::__construct
-	 * @covers CL\Atlas\SQL\SQL::content
-	 * @covers CL\Atlas\SQL\SQL::parameters
-	 * @covers CL\Atlas\SQL\SQL::__toString
-	 */
-	public function testConstructAndGetters()
-	{
-		$params = array('param1', 'param2');
-		$sql = new SQL('SQL STRING', $params);
+    /**
+     * @covers CL\Atlas\SQL\SQL::__construct
+     * @covers CL\Atlas\SQL\SQL::content
+     * @covers CL\Atlas\SQL\SQL::parameters
+     * @covers CL\Atlas\SQL\SQL::__toString
+     */
+    public function testConstructAndGetters()
+    {
+        $params = array('param1', 'param2');
+        $sql = new SQL('SQL STRING', $params);
 
-		$this->assertEquals('SQL STRING', $sql->content());
-		$this->assertEquals($params, $sql->parameters());
-		$this->assertEquals('SQL STRING', $sql->__toString());
+        $this->assertEquals('SQL STRING', $sql->content());
+        $this->assertEquals($params, $sql->parameters());
+        $this->assertEquals('SQL STRING', $sql->__toString());
 
-	}
+    }
 }

--- a/tests/src/SQL/SetSQLTest.php
+++ b/tests/src/SQL/SetSQLTest.php
@@ -10,34 +10,34 @@ use CL\Atlas\SQL\SQL;
  */
 class SetSQLTest extends AbstractTestCase {
 
-	public function dataConstruct()
-	{
-		$sql = new SQL('IF (column, 10, ?)', array(20));
-		$query = new SelectQuery();
-		$query
-			->from('table1')
-			->where(array('name' => 10))
-			->limit(1);
+    public function dataConstruct()
+    {
+        $sql = new SQL('IF (column, 10, ?)', array(20));
+        $query = new SelectQuery();
+        $query
+            ->from('table1')
+            ->where(array('name' => 10))
+            ->limit(1);
 
-		return array(
-			array('column', 20, 'column', 20, array(20)),
-			array('column', $sql, 'column', $sql, array(20)),
-			array('column', $query, 'column', $query, array(10)),
-		);
-	}
+        return array(
+            array('column', 20, 'column', 20, array(20)),
+            array('column', $sql, 'column', $sql, array(20)),
+            array('column', $query, 'column', $query, array(10)),
+        );
+    }
 
-	/**
-	 * @dataProvider dataConstruct
-	 * @covers CL\Atlas\SQL\SetSQL::__construct
-	 * @covers CL\Atlas\SQL\SetSQL::value
-	 * @covers CL\Atlas\SQL\SetSQL::parameters
-	 */
-	public function testConstruct($column, $value, $expected_column, $expected_value, $expected_params)
-	{
-		$set = new SetSQL($column, $value);
+    /**
+     * @dataProvider dataConstruct
+     * @covers CL\Atlas\SQL\SetSQL::__construct
+     * @covers CL\Atlas\SQL\SetSQL::value
+     * @covers CL\Atlas\SQL\SetSQL::parameters
+     */
+    public function testConstruct($column, $value, $expected_column, $expected_value, $expected_params)
+    {
+        $set = new SetSQL($column, $value);
 
-		$this->assertEquals($expected_column, $set->content());
-		$this->assertEquals($expected_value, $set->value());
-		$this->assertEquals($expected_params, $set->parameters());
-	}
+        $this->assertEquals($expected_column, $set->content());
+        $this->assertEquals($expected_value, $set->value());
+        $this->assertEquals($expected_params, $set->parameters());
+    }
 }

--- a/tests/src/SQL/SetSQLTest.php
+++ b/tests/src/SQL/SetSQLTest.php
@@ -8,7 +8,8 @@ use CL\Atlas\SQL\SQL;
 /**
  * @group sql.direction
  */
-class SetSQLTest extends AbstractTestCase {
+class SetSQLTest extends AbstractTestCase
+{
 
     public function dataConstruct()
     {

--- a/tests/src/SQL/ValuesSQLTest.php
+++ b/tests/src/SQL/ValuesSQLTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\SQL\ValuesSQL;
 /**
  * @group sql.values
  */
-class ValuesSQLTest extends AbstractTestCase {
+class ValuesSQLTest extends AbstractTestCase
+{
 
 
     /**

--- a/tests/src/SQL/ValuesSQLTest.php
+++ b/tests/src/SQL/ValuesSQLTest.php
@@ -9,15 +9,15 @@ use CL\Atlas\SQL\ValuesSQL;
 class ValuesSQLTest extends AbstractTestCase {
 
 
-	/**
-	 * @covers CL\Atlas\SQL\ValuesSQL::__construct
-	 */
-	public function testConstruct()
-	{
-		$values = array(10, 20);
-		$sql = new ValuesSQL($values);
+    /**
+     * @covers CL\Atlas\SQL\ValuesSQL::__construct
+     */
+    public function testConstruct()
+    {
+        $values = array(10, 20);
+        $sql = new ValuesSQL($values);
 
-		$this->assertEquals(NULL, $sql->content());
-		$this->assertEquals($values, $sql->parameters());
-	}
+        $this->assertEquals(NULL, $sql->content());
+        $this->assertEquals($values, $sql->parameters());
+    }
 }

--- a/tests/src/SQL/ValuesSQLTest.php
+++ b/tests/src/SQL/ValuesSQLTest.php
@@ -17,7 +17,7 @@ class ValuesSQLTest extends AbstractTestCase {
         $values = array(10, 20);
         $sql = new ValuesSQL($values);
 
-        $this->assertEquals(NULL, $sql->content());
+        $this->assertEquals(null, $sql->content());
         $this->assertEquals($values, $sql->parameters());
     }
 }

--- a/tests/src/StrTest.php
+++ b/tests/src/StrTest.php
@@ -6,7 +6,8 @@ use CL\Atlas\Str;
 /**
  * @group str
  */
-class StrTest extends AbstractTestCase {
+class StrTest extends AbstractTestCase
+{
 
     public function dataReplace()
     {

--- a/tests/src/StrTest.php
+++ b/tests/src/StrTest.php
@@ -12,9 +12,24 @@ class StrTest extends AbstractTestCase
     public function dataReplace()
     {
         return array(
-            array("/\?/", array('1', '2'), "this is ? a test ? here", "this is 1 a test 2 here"),
-            array("/\?/", array('7342'), "SELECT time FROM test WHERE id = ?", "SELECT time FROM test WHERE id = 7342"),
-            array("/\?/", array('7342', '(1, 2)'), "SELECT time FROM test WHERE id = ? AND num IN ?", "SELECT time FROM test WHERE id = 7342 AND num IN (1, 2)"),
+            array(
+                "/\?/",
+                array('1', '2'),
+                "this is ? a test ? here",
+                "this is 1 a test 2 here"
+            ),
+            array(
+                "/\?/",
+                array('7342'),
+                "SELECT time FROM test WHERE id = ?",
+                "SELECT time FROM test WHERE id = 7342"
+            ),
+            array(
+                "/\?/",
+                array('7342', '(1, 2)'),
+                "SELECT time FROM test WHERE id = ? AND num IN ?",
+                "SELECT time FROM test WHERE id = 7342 AND num IN (1, 2)"
+            ),
         );
     }
 

--- a/tests/src/StrTest.php
+++ b/tests/src/StrTest.php
@@ -8,21 +8,21 @@ use CL\Atlas\Str;
  */
 class StrTest extends AbstractTestCase {
 
-	public function dataReplace()
-	{
-		return array(
-			array("/\?/", array('1', '2'), "this is ? a test ? here", "this is 1 a test 2 here"),
-			array("/\?/", array('7342'), "SELECT time FROM test WHERE id = ?", "SELECT time FROM test WHERE id = 7342"),
-			array("/\?/", array('7342', '(1, 2)'), "SELECT time FROM test WHERE id = ? AND num IN ?", "SELECT time FROM test WHERE id = 7342 AND num IN (1, 2)"),
-		);
-	}
+    public function dataReplace()
+    {
+        return array(
+            array("/\?/", array('1', '2'), "this is ? a test ? here", "this is 1 a test 2 here"),
+            array("/\?/", array('7342'), "SELECT time FROM test WHERE id = ?", "SELECT time FROM test WHERE id = 7342"),
+            array("/\?/", array('7342', '(1, 2)'), "SELECT time FROM test WHERE id = ? AND num IN ?", "SELECT time FROM test WHERE id = 7342 AND num IN (1, 2)"),
+        );
+    }
 
-	/**
-	 * @dataProvider dataReplace
-	 * @covers CL\Atlas\Str::replace
-	 */
-	public function testReplace($pattern, $replacements, $subject, $expected)
-	{
-		$this->assertEquals($expected, Str::replace($pattern, $replacements, $subject));
-	}
+    /**
+     * @dataProvider dataReplace
+     * @covers CL\Atlas\Str::replace
+     */
+    public function testReplace($pattern, $replacements, $subject, $expected)
+    {
+        $this->assertEquals($expected, Str::replace($pattern, $replacements, $subject));
+    }
 }


### PR DESCRIPTION
Some of the conventions were already introduced to the codebase.

I thought I would suggest a complete rewrite to PSR-2 by just implementing it.

---

I've used `phpcs --standard=psr2 src/ tests/` command to verify the results.
The remaining warnings are about some long lines of HEREDOC, but I couldn't fix them unless I substantially change the code.

---

I've grouped my changes into commits corresponding to the various rules.
