### PR TITLE
Test in Travis on PHP 5.6 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 before_install:


### PR DESCRIPTION
PHP 5.6 may not be released yet, but it will be soon. Travis CI already support its latest beta.
